### PR TITLE
Update Apache license to include Graph Protocol copyright specifics

### DIFF
--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -175,17 +175,6 @@ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
 END OF TERMS AND CONDITIONS
 
-APPENDIX: How to apply the Apache License to your work.
-
-   To apply the Apache License to your work, attach the following
-   boilerplate notice, with the fields enclosed by brackets "[]"
-   replaced with your own identifying information. (Don't include
-   the brackets!)  The text should be enclosed in the appropriate
-   comment syntax for the file format. We also recommend that a
-   file or class name and description of purpose be included on the
-   same "printed page" as the copyright notice for easier
-   identification within third-party archives.
-
 Copyright (c) 2018 Graph Protocol, Inc. and contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -186,7 +186,7 @@ APPENDIX: How to apply the Apache License to your work.
    same "printed page" as the copyright notice for easier
    identification within third-party archives.
 
-Copyright [yyyy] [name of copyright owner]
+Copyright (c) 2018 Graph Protocol, Inc. and contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ As of today, the command line interface consists of two commands:
 - smart contract ABIs, and
 - mappings written in TypeScript/AssemblyScript,
 
-compiles the mappings to WebAssmebly and deploys a ready-to-use
+compiles the mappings to WebAssembly and deploys a ready-to-use
 version of the subgraph to IPFS or a local directory for debugging.
 
 ## Usage
@@ -71,3 +71,9 @@ Copyright &copy; 2018 Graph Protocol, Inc. and contributors.
 
 The Graph CLI is dual-licensed under the [MIT license](LICENSE-MIT) and the
 [Apache License, Version 2.0](LICENSE-APACHE).
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
Boilerplate copyright specification was still hidden in the bottom of the Apache license.  It has been updated to include the year and owner information. 