### PR TITLE
JSON conversion to number types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -249,6 +249,10 @@ declare type JSONValuePayload = u64
 declare class JSONValue {
   isNull(): boolean
   toBool(): boolean
+  toI64(): i64
+  toU64(): u64
+  toF64(): f64
+  toBigInt(): BigInt
   toString(): string
   toArray(): Array<JSONValue>
   toObject(): TypedMap<string, JSONValue>

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -22,6 +22,10 @@ declare namespace ipfs {
 /** Host JSON interface */
 declare namespace json {
   function fromBytes(data: Bytes): JSONValue
+  function toI64(decimal: string): i64
+  function toU64(decimal: string): u64
+  function toF64(decimal: string): f64
+  function toBigInt(decimal: string): BigInt
 }
 
 /** Host type conversion interface */
@@ -685,7 +689,29 @@ class JSONValue {
     return this.data != 0
   }
 
-  // TODO: Conversion to number types.
+  toI64(): i64 {
+    assert(this.kind == JSONValueKind.NUMBER, 'JSON value is not a number.')
+    let decimalString = changetype<string>(this.data as u32)
+    return json.toI64(decimalString)
+  }
+
+  toU64(): u64 {
+    assert(this.kind == JSONValueKind.NUMBER, 'JSON value is not a number.')
+    let decimalString = changetype<string>(this.data as u32)
+    return json.toU64(decimalString)
+  }
+
+  toF64(): f64 {
+    assert(this.kind == JSONValueKind.NUMBER, 'JSON value is not a number.')
+    let decimalString = changetype<string>(this.data as u32)
+    return json.toF64(decimalString)
+  }
+
+  toBigInt(): BigInt {
+    assert(this.kind == JSONValueKind.NUMBER, 'JSON value is not a number.')
+    let decimalString = changetype<string>(this.data as u32)
+    return json.toBigInt(decimalString)
+  }
 
   toString(): string {
     assert(this.kind == JSONValueKind.STRING, 'JSON value is not a string.')

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -1,7 +1,7 @@
 import 'allocator/arena'
 
 // Export allocator functions for hosts to manage WASM memory
-export { allocate_memory, free_memory }
+export { allocate_memory }
 
 /** Host store interface */
 declare namespace store {


### PR DESCRIPTION
Resolves #69.

Assumes numbers are received as strings as per graphprotocol/graph-node#253.