### PR TITLE
Add Address.fromString and H160.fromString constructors

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -58,7 +58,9 @@ declare class U64Array extends Uint64Array {
 }
 
 /** An Ethereum address (20 bytes). */
-declare type Address = ByteArray
+declare class Address extends ByteArray {
+  fromString(s: String): Address
+}
 
 /** An arbitrary size integer. */
 declare type BigInt = ByteArray
@@ -67,7 +69,9 @@ declare type BigInt = ByteArray
 declare type Bytes = ByteArray
 
 /** A 160-bit hash. */
-declare type H160 = ByteArray
+declare class H160 extends ByteArray {
+  fromString(s: String): H160
+}
 
 /** A 256-bit hash. */
 declare type H256 = ByteArray

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -194,9 +194,9 @@ class EthereumValue {
     if (this.kind == EthereumValueKind.ADDRESS) {
       return changetype<Address>(this.data as u32)
     } else if (this.kind == EthereumValueKind.UINT) {
-      return typeConversion.u256ToH160(this.toU256())
+      return typeConversion.u256ToH160(this.toU256()) as Address
     } else if (this.kind == EthereumValueKind.INT) {
-      return typeConversion.u256ToH160(this.toI128())
+      return typeConversion.u256ToH160(this.toI128()) as Address
     }
     throw new Error('Type conversion from ' + this.kind + ' to address not supported')
   }

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -41,6 +41,7 @@ declare namespace typeConversion {
   function u256ToH160(u: U256): H160
   function u256ToH256(u: U256): H256
   function int256ToBigInt(u: U256): BigInt
+  function stringToH160(s: String): H160
 }
 
 /**
@@ -122,7 +123,11 @@ class U64Array extends Uint64Array {
 }
 
 /** An Ethereum address (20 bytes). */
-type Address = ByteArray
+class Address extends ByteArray {
+  fromString(s: String): Address {
+    return changetype<Address>(typeConversion.stringToH160(s))
+  }
+}
 
 /** An arbitrary size integer. */
 type BigInt = ByteArray
@@ -131,7 +136,11 @@ type BigInt = ByteArray
 type Bytes = ByteArray
 
 /** A 160-bit hash. */
-type H160 = ByteArray
+class H160 extends ByteArray {
+  fromString(s: String): H160 {
+    return typeConversion.stringToH160(s)
+  }
+}
 
 /** A 256-bit hash. */
 type H256 = ByteArray

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -124,7 +124,7 @@ class U64Array extends Uint64Array {
 
 /** An Ethereum address (20 bytes). */
 class Address extends ByteArray {
-  fromString(s: String): Address {
+  static fromString(s: String): Address {
     return changetype<Address>(typeConversion.stringToH160(s))
   }
 }
@@ -137,7 +137,7 @@ type Bytes = ByteArray
 
 /** A 160-bit hash. */
 class H160 extends ByteArray {
-  fromString(s: String): H160 {
+  static fromString(s: String): H160 {
     return typeConversion.stringToH160(s)
   }
 }


### PR DESCRIPTION
Resolves #86.

These two constructors are backed by a host-exported `stringToH160` type conversion function.