### PR TITLE
Add Travis configuration and badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: node_js
+node_js:
+  - "8"
+  - "9"
+  - "10"
+cache: yarn
+script:
+  - ./graph.js codegen examples/example-event-handler/subgraph.yaml --verbosity debug
+  - ./graph.js build examples/example-event-handler/subgraph.yaml --verbosity debug

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # The Graph CLI (graph-cli)
 
+[![Build Status](https://travis-ci.org/graphprotocol/graph-cli.svg?branch=master)](https://travis-ci.org/graphprotocol/graph-cli)
+
 The Graph command line interface.
 
 As of today, the command line interface consists of two commands:


### PR DESCRIPTION
This resolves #91. Whenever code is pushed to the repo now, we're checking that both `graph codegen` and `graph build` work against the example subgraph included in the repo. More tests to follow once we have a test story/framework for subgraphs/mappings.