### PR TITLE
Fix loading ABIs built by Truffle

### DIFF
--- a/src/cli/abi.js
+++ b/src/cli/abi.js
@@ -242,6 +242,8 @@ module.exports = class ABI {
 
   static load(name, file) {
     let data = JSON.parse(fs.readFileSync(file))
-    return new ABI(name, file, immutable.fromJS(data))
+    return Array.isArray(data)
+      ? new ABI(name, file, immutable.fromJS(data))
+      : new ABI(name, file, immutable.fromJS(data.abi))
   }
 }


### PR DESCRIPTION
These ABI files will be a map with a `contractName` and `abi` field,
rather than an array of type, function and event definitions.

If this is the case, we now load from the `abi` field, otherwise
we stick to the top level array.