### PR TITLE
[ethberlin] runtime: Use `Array<Value>` instead of `Array<T>`

### DIFF
--- a/examples/example-event-handler/dist/ExampleSubgraph/ExampleSubgraph.ts
+++ b/examples/example-event-handler/dist/ExampleSubgraph/ExampleSubgraph.ts
@@ -494,9 +494,9 @@ class Value {
     return changetype<string>(this.data as u32)
   }
 
-  toArray<T>(): Array<T> {
+  toArray(): Array<Value> {
     assert(this.kind == ValueKind.ARRAY, 'Value is not an array.')
-    return changetype<Array<T>>(this.data as u32)
+    return changetype<Array<Value>>(this.data as u32)
   }
 
   static fromAddress(address: Address): Value {
@@ -561,7 +561,7 @@ class Value {
     return value
   }
 
-  static fromArray<T>(array: Array<T>): Value {
+  static fromArray(array: Array<Value>): Value {
     let value = new Value()
     value.kind = ValueKind.ARRAY
     value.data = array as u64
@@ -600,7 +600,7 @@ class Entity extends TypedMap<string, Value> {
     return this.get(key).toString()
   }
 
-  getArray<T>(key: string): Array<T> {
+  getArray(key: string): Array<Value> {
     return this.get(key).toArray()
   }
 
@@ -636,7 +636,7 @@ class Entity extends TypedMap<string, Value> {
     this.set(key, Value.fromU256(value))
   }
 
-  setArray<T>(key: string, array: Array<T>): void {
+  setArray(key: string, array: Array<Value>): void {
     this.set(key, Value.fromArray(array))
   }
 

--- a/examples/example-event-handler/dist/ExampleSubgraph/abis/ExampleContract.json
+++ b/examples/example-event-handler/dist/ExampleSubgraph/abis/ExampleContract.json
@@ -1,7 +1,13 @@
 [
   {
     "anonymous": false,
-    "inputs": [{ "indexed": true, "name": "exampleParam", "type": "string" }],
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "exampleParam",
+        "type": "string"
+      }
+    ],
     "name": "ExampleEvent",
     "type": "event"
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -188,7 +188,7 @@ declare class Value {
   toBytes(): Bytes
   toU32(): u32
   toString(): string
-  toArray<T>(array: Array<T>): Value
+  toArray(array: Array<Value>): Value
 
   static fromAddress(address: Address): Value
   static fromBoolean(b: boolean): Value
@@ -199,7 +199,7 @@ declare class Value {
   static fromU256(n: U256): Value
   static fromString(s: string): Value
   static fromNull(): Value
-  static fromArray<T>(array: Array<T>): Value
+  static fromArray(array: Array<Value>): Value
 }
 
 /**
@@ -215,7 +215,7 @@ declare class Entity extends TypedMap<string, Value> {
   getBytes(key: string): Bytes
   getU32(key: string): u32
   getString(key: string): string
-  getArray<T>(key: string): Array<T>
+  getArray(key: string): Array<Value>
 
   setAddress(key: string, value: Address): void
   setBoolean(key: string, value: boolean): void
@@ -225,7 +225,7 @@ declare class Entity extends TypedMap<string, Value> {
   setU32(key: string, value: u32): void
   setU256(key: string, value: U256): void
   setString(key: string, value: string): void
-  setArray<T>(key: string, array: Array<T>): void
+  setArray(key: string, array: Array<Value>): void
   unset(key: string): void
   /** Assigns properties from source to this Entity in right-to-left order */
   merge(sources: Array<Entity>): Entity

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -494,9 +494,9 @@ class Value {
     return changetype<string>(this.data as u32)
   }
 
-  toArray<T>(): Array<T> {
+  toArray(): Array<Value> {
     assert(this.kind == ValueKind.ARRAY, 'Value is not an array.')
-    return changetype<Array<T>>(this.data as u32)
+    return changetype<Array<Value>>(this.data as u32)
   }
 
   static fromAddress(address: Address): Value {
@@ -561,7 +561,7 @@ class Value {
     return value
   }
 
-  static fromArray<T>(array: Array<T>): Value {
+  static fromArray(array: Array<Value>): Value {
     let value = new Value()
     value.kind = ValueKind.ARRAY
     value.data = array as u64
@@ -600,7 +600,7 @@ class Entity extends TypedMap<string, Value> {
     return this.get(key).toString()
   }
 
-  getArray<T>(key: string): Array<T> {
+  getArray(key: string): Array<Value> {
     return this.get(key).toArray()
   }
 
@@ -636,7 +636,7 @@ class Entity extends TypedMap<string, Value> {
     this.set(key, Value.fromU256(value))
   }
 
-  setArray<T>(key: string, array: Array<T>): void {
+  setArray(key: string, array: Array<Value>): void {
     this.set(key, Value.fromArray(array))
   }
 


### PR DESCRIPTION
Note that this PR is against the `ethberlin` branch.