### PR TITLE
runtime, cli: Remove `block_hash` parameter from `bind`

### DIFF
--- a/examples/example-event-handler/dist/ExampleSubgraph/ExampleSubgraph.ts
+++ b/examples/example-event-handler/dist/ExampleSubgraph/ExampleSubgraph.ts
@@ -700,20 +700,17 @@ class EthereumEventParam {
 }
 
 class SmartContractCall {
-  blockHash: H256
   contractName: string
   contractAddress: Address
   functionName: string
   functionParams: Array<EthereumValue>
 
   constructor(
-    blockHash: H256,
     contractName: string,
     contractAddress: Address,
     functionName: string,
     functionParams: Array<EthereumValue>
   ) {
-    this.blockHash = blockHash
     this.contractName = contractName
     this.contractAddress = contractAddress
     this.functionName = functionName
@@ -727,17 +724,14 @@ class SmartContractCall {
 class SmartContract {
   name: string
   address: Address
-  blockHash: H256
 
   protected constructor(name: string, address: Address, blockHash: H256) {
     this.name = name
     this.address = address
-    this.blockHash = blockHash
   }
 
   call(name: string, params: Array<EthereumValue>): Array<EthereumValue> {
     let call = new SmartContractCall(
-      this.blockHash,
       this.name,
       this.address,
       name,
@@ -836,8 +830,8 @@ class ExampleEventParams {
 }
 
 class ExampleContract extends SmartContract {
-  static bind(address: Address, blockHash: H256): ExampleContract {
-    return new ExampleContract("ExampleContract", address, blockHash);
+  static bind(address: Address): ExampleContract {
+    return new ExampleContract("ExampleContract", address);
   }
 }
 

--- a/src/cli/abi.js
+++ b/src/cli/abi.js
@@ -84,11 +84,10 @@ module.exports = class ABI {
         'bind',
         immutable.List([
           codegen.param('address', codegen.simpleType('address')),
-          codegen.param('blockHash', codegen.simpleType('h256')),
         ]),
         klass,
         `
-        return new ${this.name}('${this.name}', address, blockHash);
+        return new ${this.name}('${this.name}', address);
         `
       )
     )

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -700,20 +700,17 @@ class EthereumEventParam {
 }
 
 class SmartContractCall {
-  blockHash: H256
   contractName: string
   contractAddress: Address
   functionName: string
   functionParams: Array<EthereumValue>
 
   constructor(
-    blockHash: H256,
     contractName: string,
     contractAddress: Address,
     functionName: string,
     functionParams: Array<EthereumValue>
   ) {
-    this.blockHash = blockHash
     this.contractName = contractName
     this.contractAddress = contractAddress
     this.functionName = functionName
@@ -727,17 +724,14 @@ class SmartContractCall {
 class SmartContract {
   name: string
   address: Address
-  blockHash: H256
 
   protected constructor(name: string, address: Address, blockHash: H256) {
     this.name = name
     this.address = address
-    this.blockHash = blockHash
   }
 
   call(name: string, params: Array<EthereumValue>): Array<EthereumValue> {
     let call = new SmartContractCall(
-      this.blockHash,
       this.name,
       this.address,
       name,


### PR DESCRIPTION
It's redundant, the node already has that information.

This is an API-breaking change and also not compatible with older versions of graph-node.

Resolves #102.
Companion PR for node https://github.com/graphprotocol/graph-node/pull/399