### PR TITLE
runtime: Remove dead `blockHash` parameter

### DIFF
--- a/examples/example-event-handler/dist/ExampleSubgraph/ExampleSubgraph.ts
+++ b/examples/example-event-handler/dist/ExampleSubgraph/ExampleSubgraph.ts
@@ -725,7 +725,7 @@ class SmartContract {
   name: string
   address: Address
 
-  protected constructor(name: string, address: Address, blockHash: H256) {
+  protected constructor(name: string, address: Address) {
     this.name = name
     this.address = address
   }

--- a/examples/example-event-handler/types/ExampleSubgraph/ExampleContract.types.ts
+++ b/examples/example-event-handler/types/ExampleSubgraph/ExampleContract.types.ts
@@ -1,0 +1,23 @@
+class ExampleEvent extends EthereumEvent {
+  get params(): ExampleEventParams {
+    return new ExampleEventParams(this);
+  }
+}
+
+class ExampleEventParams {
+  _event: ExampleEvent;
+
+  constructor(event: ExampleEvent) {
+    this._event = event;
+  }
+
+  get exampleParam(): string {
+    return this._event.parameters[0].value.toString();
+  }
+}
+
+class ExampleContract extends SmartContract {
+  static bind(address: Address): ExampleContract {
+    return new ExampleContract("ExampleContract", address);
+  }
+}

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -725,7 +725,7 @@ class SmartContract {
   name: string
   address: Address
 
-  protected constructor(name: string, address: Address, blockHash: H256) {
+  protected constructor(name: string, address: Address) {
     this.name = name
     this.address = address
   }


### PR DESCRIPTION
This was left behind when removing `blockHash` from `bind`.