### PR TITLE
Implement `graph remove`

### DIFF
--- a/examples/example-event-handler/dist/ExampleSubgraph/abis/ExampleContract.json
+++ b/examples/example-event-handler/dist/ExampleSubgraph/abis/ExampleContract.json
@@ -1,0 +1,14 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "exampleParam",
+        "type": "string"
+      }
+    ],
+    "name": "ExampleEvent",
+    "type": "event"
+  }
+]

--- a/examples/example-event-handler/dist/subgraph.yaml
+++ b/examples/example-event-handler/dist/subgraph.yaml
@@ -16,7 +16,7 @@ dataSources:
         - ExampleEntity
       abis:
         - name: ExampleContract
-          file: abis/ExampleContract.json
+          file: ExampleSubgraph/abis/ExampleContract.json
       eventHandlers:
         - event: ExampleEvent(string)
           handler: handleExampleEvent

--- a/graph.js
+++ b/graph.js
@@ -233,10 +233,10 @@ app
   .description('Removes subgraph from node')
   .option(
     '-k, --api-key <KEY>',
-    'Graph API key authorized to deploy to the subgraph name'
+    'Graph API key authorized to manage the subgraph name'
   )
-  .option('-g, --node <URL>[:PORT]', 'Graph node')
-  .option('-n, --subgraph-name <NAME>', 'Subgraph name')
+  .option('-g, --node <URL>[:PORT]', 'Graph node to remove the subgraph from')
+  .option('-n, --subgraph-name <NAME>', 'Subgraph name to remove')
   .action(cmd => {
     if (
       cmd.subgraphName === undefined ||


### PR DESCRIPTION
Corresponds to the `subgraph_remove` json-rpc endpoint. Example invocation: `yarn graph remove --node http://127.0.0.1:8020/ -n ens`.

Depends on https://github.com/graphprotocol/graph-node/pull/512 landing on the node.