### PR TITLE
Print routes returned by graph node

### DIFF
--- a/graph.js
+++ b/graph.js
@@ -197,10 +197,14 @@ app
             logger.fatal('Error deploying the subgraph:', jsonRpcError.message)
           }
           if (!requestError && !jsonRpcError) {
-            logger.status(
-              'Deployed to Graph node:',
-              path.join(requestUrl.toString(), cmd.subgraphName)
-            )
+            logger.status('Deployed to Graph node:', requestUrl.toString())
+            
+            // Assume that the host is the same.
+            // In the future the deployment router should also return the host.
+            let base = requestUrl.protocol + '//' + requestUrl.hostname
+            logger.status('Playground', base + res.playground)
+            logger.status('Queries (HTTP)', base + res.queries)
+            logger.status('Subscriptions (WS)', base + res.subscriptions)
           }
         }
       )

--- a/graph.js
+++ b/graph.js
@@ -197,14 +197,14 @@ app
             logger.fatal('Error deploying the subgraph:', jsonRpcError.message)
           }
           if (!requestError && !jsonRpcError) {
-            logger.status('Deployed to Graph node:', requestUrl.toString())
+            logger.status('Deployed successfully.')
             
             // Assume that the host is the same.
             // In the future the deployment router should also return the host.
             let base = requestUrl.protocol + '//' + requestUrl.hostname
-            logger.status('Playground', base + res.playground)
-            logger.status('Queries (HTTP)', base + res.queries)
-            logger.status('Subscriptions (WS)', base + res.subscriptions)
+            logger.status('Playground:         ', base + res.playground)
+            logger.status('Queries (HTTP):     ', base + res.queries)
+            logger.status('Subscriptions (WS): ', base + res.subscriptions)
           }
         }
       )


### PR DESCRIPTION
Prints something like:
```
Deployed to Graph node: http://127.0.0.1:8020/
Playground http://127.0.0.1:8000/ens
Queries (HTTP) http://127.0.0.1:8000/ens/graphql
Subscriptions (WS) http://127.0.0.1:8001/ens
```

Depends on https://github.com/graphprotocol/graph-node/pull/521 in the node.