### PR TITLE
Support abi under compilerOutput

### DIFF
--- a/src/abi.js
+++ b/src/abi.js
@@ -268,8 +268,20 @@ module.exports = class ABI {
 
   static load(name, file) {
     let data = JSON.parse(fs.readFileSync(file))
-    return Array.isArray(data)
-      ? new ABI(name, file, immutable.fromJS(data))
-      : new ABI(name, file, immutable.fromJS(data.abi))
+
+    let abi = null
+    if (Array.isArray(data)) {
+      abi = data
+    } else if (data.abi !== undefined) {
+      abi = data.abi
+    } else if (data.compilerOutput !== undefined && data.compilerOutput.abi !== undefined) {
+      abi = data.compilerOutput.abi
+    }
+
+    if (!abi) {
+      throw Error(`Could not extract abi from file ${file}`)
+    }
+  
+    return new ABI(name, file, immutable.fromJS(abi))
   }
 }

--- a/src/abi.js
+++ b/src/abi.js
@@ -279,7 +279,7 @@ module.exports = class ABI {
     }
 
     if (abi === null || abi === undefined) {
-      throw Error(`Could not extract abi from ${file}`)
+      throw Error(`Could not extract ABI from ${file}`)
     }
   
     return new ABI(name, file, immutable.fromJS(abi))

--- a/src/abi.js
+++ b/src/abi.js
@@ -278,8 +278,8 @@ module.exports = class ABI {
       abi = data.compilerOutput.abi
     }
 
-    if (!abi) {
-      throw Error(`Could not extract abi from file ${file}`)
+    if (abi === null || abi === undefined) {
+      throw Error(`Could not extract abi from ${file}`)
     }
   
     return new ABI(name, file, immutable.fromJS(abi))


### PR DESCRIPTION
Makes abi loading more robust, doing better error checking and supporting abis under the compilerOutput key which is something that was found in the wild by @davekaj. Dave, could you check that this works for you?

My javascript style is probably crap, I'm sure @Jannis can give me some hints.