### PR TITLE
compiler: Add contents `graph-ts/global` to libs

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -194,13 +194,15 @@ class Compiler {
         throw e
       }
 
+      let libs = path.join(baseDir, 'node_modules');
+      let global = path.join(libs, '@graphprotocol', 'graph-ts', 'global')
       asc.main(
         [
           inputFile,
           '--baseDir',
           baseDir,
           '--lib',
-          path.join(baseDir, 'node_modules'),
+          `${libs},${global}`,
           '--outFile',
           outputFile,
         ],


### PR DESCRIPTION
So that `global.ts` which contains `allocate_memory` gets put in the global namespace of every mapping.

Does nothing until we use a graph-ts that contains `global/global.ts`. See https://github.com/graphprotocol/graph-ts/pull/15.

A mapping that uses a cli with this patch and a graph-ts with https://github.com/graphprotocol/graph-ts/pull/15 must remove its own `allocate_memory` export so it doesn't cause a name conflict with the one being imported here.