### PR TITLE
Update README: Include deploy and remove in list of commands, readability and consistency updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,12 @@
 
 The Graph command line interface.
 
-As of today, the command line interface consists of three commands:
+As of today, the command line interface consists of five commands:
 
 - `graph codegen` — generates TypeScript code for smart contract ABIs used in subgraphs.
 - `graph build` — compiles subgraphs to WebAssembly and deploys them to IPFS.
+- `graph deploy` — deploys subgraphs to running [Graph Nodes](https://github.com/graphprotocol/graph-node).
+- `graph remove` — removes subgraphs from [Graph Nodes](https://github.com/graphprotocol/graph-node).
 - `graph auth` — saves access token for [Graph Node](https://github.com/graphprotocol/graph-node) to the system's keychain.
 
 ## How It Works
@@ -42,7 +44,7 @@ your distribution:
 - Red Hat: `sudo yum install libsecret-devel`
 - Arch Linux: `sudo pacman -S libsecret`
 
-### Steps 
+### Steps
 
 1.  Create a project for the subgraph with a `package.json` etc.
 2.  Add a `subgraph.yaml` subgraph manifest with a GraphQL schema etc.
@@ -114,6 +116,14 @@ your distribution:
     make sure to authorize with the node using e.g. `graph auth http://127.0.0.`:8020 <ACCESS_TOKEN>`
     before deploying._
 
+Remove a subgraph from the [Graph Node](https://github.com/graphprotocol/graph-node) with:
+```sh
+graph \
+  remove \
+  --api-key <key> \
+  --node http://127.0.0.1:8020/ \
+  --subgraph-name <your-subgraph>
+```
 ## License
 
 Copyright &copy; 2018 Graph Protocol, Inc. and contributors.

--- a/README.md
+++ b/README.md
@@ -15,22 +15,19 @@ As of today, the command line interface consists of five commands:
 
 ## How It Works
 
-`graph` takes a subgraph manifest with references to
+`graph` takes a subgraph manifest (defaults to `subgraph.yaml`) with references to
 
 - a GraphQL schema,
 - smart contract ABIs
 - mappings written in TypeScript/AssemblyScript
 
-compiles the mappings to WebAssembly,
-builds a ready-to-use version of the subgraph to IPFS or a local directory for debugging,
-and deploys the subgraph to a [Graph Node](https://github.com/graphprotocol/graph-node).
-
+compiles the mappings to WebAssembly, builds a ready-to-use version of the subgraph saved to IPFS or a local directory for debugging, and deploys the subgraph to a [Graph Node](https://github.com/graphprotocol/graph-node).
 
 ## Usage
 
-Subgraphs for The Graph are set up just like any regular TypeScript
+Subgraphs for The Graph are set up like a typical TypeScript
 project. It is recommended to install `graph-cli` as a local dependency
-via `package.json` and use `yarn` scripts for code generation and
+via `package.json` and use `npm` scripts for code generation and
 building.
 
 If you are just getting started with creating a subgraph, head to [getting started](https://github.com/graphprotocol/graph-node/blob/master/docs/getting-started.md). Eventually this guide will lead you back here.
@@ -81,7 +78,7 @@ your distribution:
         "build": "graph build",
         "build-ipfs": "graph build --ipfs /ip4/127.0.0.1/tcp/5001",
         "deploy":
-          "graph deploy --ipfs /ip4/127.0.0.1/tcp/5001 --node http://127.0.0.1:8020 --subgraph-name <YOUR-SUBGRAPH>"
+          "graph deploy --ipfs /ip4/127.0.0.1/tcp/5001 --node http://127.0.0.1:8020 --subgraph-name <SUBGRAPH_NAME>"
       }
     }
     ```
@@ -112,7 +109,7 @@ your distribution:
        --verbosity debug \
        --node http://127.0.0.1:8020/ \
        --ipfs /ip4/127.0.0.1/tcp/5001 \
-       --subgraph-name <YOUR-SUBGRAPH>
+       --subgraph-name <SUBGRAPH_NAME>
     ```
     _Note: If the Graph Node you are deploying to requires authorization,
     make sure to authorize with the node using e.g. `graph auth http://127.0.0.`:8020 <ACCESS_TOKEN>`
@@ -124,7 +121,7 @@ graph \
   remove \
   --api-key <KEY> \
   --node http://127.0.0.1:8020/ \
-  --subgraph-name <YOUR-SUBGRAPH>
+  --subgraph-name <SUBGRAPH_NAME>
 ```
 ## License
 

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ As of today, the command line interface consists of five commands:
 `graph` takes a subgraph manifest (defaults to `subgraph.yaml`) with references to
 
 - a GraphQL schema,
-- smart contract ABIs
-- mappings written in TypeScript/AssemblyScript
+- smart contract ABIs,
+- mappings written in TypeScript/AssemblyScript.
 
-compiles the mappings to WebAssembly, builds a ready-to-use version of the subgraph saved to IPFS or a local directory for debugging, and deploys the subgraph to a [Graph Node](https://github.com/graphprotocol/graph-node).
+It compiles the mappings to WebAssembly, builds a ready-to-use version of the subgraph saved to IPFS or a local directory for debugging, and deploys the subgraph to a [Graph Node](https://github.com/graphprotocol/graph-node).
 
 ## Usage
 
@@ -115,11 +115,10 @@ your distribution:
     make sure to authorize with the node using e.g. `graph auth http://127.0.0.`:8020 <ACCESS_TOKEN>`
     before deploying._
 
-If you need to remove a subgraph from the [Graph Node](https://github.com/graphprotocol/graph-node) use:
+To remove a subgraph from the [Graph Node](https://github.com/graphprotocol/graph-node), use:
 ```sh
 graph \
   remove \
-  --api-key <KEY> \
   --node http://127.0.0.1:8020/ \
   --subgraph-name <SUBGRAPH_NAME>
 ```

--- a/README.md
+++ b/README.md
@@ -15,20 +15,22 @@ As of today, the command line interface consists of five commands:
 
 ## How It Works
 
-`graph` takes a subgraph manifest (defaults to `subgraph.yaml`) with
+`graph` takes a subgraph manifest with references to
 
-- references to a GraphQL schema,
-- smart contract ABIs, and
-- mappings written in TypeScript/AssemblyScript,
+- a GraphQL schema,
+- smart contract ABIs
+- mappings written in TypeScript/AssemblyScript
 
-compiles the mappings to WebAssembly and deploys a ready-to-use
-version of the subgraph to IPFS or a local directory for debugging.
+compiles the mappings to WebAssembly,
+builds a ready-to-use version of the subgraph to IPFS or a local directory for debugging,
+and deploys the subgraph to a [Graph Node](https://github.com/graphprotocol/graph-node).
+
 
 ## Usage
 
 Subgraphs for The Graph are set up just like any regular TypeScript
 project. It is recommended to install `graph-cli` as a local dependency
-via `package.json` and use `npm` scripts for code generation and
+via `package.json` and use `yarn` scripts for code generation and
 building.
 
 If you are just getting started with creating a subgraph, head to [getting started](https://github.com/graphprotocol/graph-node/blob/master/docs/getting-started.md). Eventually this guide will lead you back here.
@@ -116,7 +118,7 @@ your distribution:
     make sure to authorize with the node using e.g. `graph auth http://127.0.0.`:8020 <ACCESS_TOKEN>`
     before deploying._
 
-Remove a subgraph from the [Graph Node](https://github.com/graphprotocol/graph-node) with:
+If you need to remove a subgraph from the [Graph Node](https://github.com/graphprotocol/graph-node) use:
 ```sh
 graph \
   remove \

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ As of today, the command line interface consists of five commands:
 
 - `graph codegen` — generates TypeScript code for smart contract ABIs used in subgraphs.
 - `graph build` — compiles subgraphs to WebAssembly and deploys them to IPFS.
-- `graph deploy` — deploys subgraphs to running [Graph Nodes](https://github.com/graphprotocol/graph-node).
-- `graph remove` — removes subgraphs from [Graph Nodes](https://github.com/graphprotocol/graph-node).
+- `graph deploy` — deploys subgraphs to a [Graph Node](https://github.com/graphprotocol/graph-node).
+- `graph remove` — removes subgraphs from a [Graph Node](https://github.com/graphprotocol/graph-node).
 - `graph auth` — saves access token for [Graph Node](https://github.com/graphprotocol/graph-node) to the system's keychain.
 
 ## How It Works
@@ -79,7 +79,7 @@ your distribution:
         "build": "graph build",
         "build-ipfs": "graph build --ipfs /ip4/127.0.0.1/tcp/5001",
         "deploy":
-          "graph deploy --ipfs /ip4/127.0.0.1/tcp/5001 --node http://127.0.0.1:8020 --subgraph-name your-subgraph"
+          "graph deploy --ipfs /ip4/127.0.0.1/tcp/5001 --node http://127.0.0.1:8020 --subgraph-name <YOUR-SUBGRAPH>"
       }
     }
     ```
@@ -97,7 +97,7 @@ your distribution:
 7.  Develop your `mapping.ts` against these generated types. If you are new to this process, you can head over to [getting started](https://github.com/graphprotocol/graph-node/blob/master/docs/getting-started.md#34-write-your-mappings) for a beginner friendly walkthrough of The Graph.
 8.  Build the subgraph with:
     ```sh
-    yarn deploy
+    yarn build
     ```
 9.  Deploy your subgraph to a
     [Graph Node](https://github.com/graphprotocol/graph-node). The following
@@ -110,7 +110,7 @@ your distribution:
        --verbosity debug \
        --node http://127.0.0.1:8020/ \
        --ipfs /ip4/127.0.0.1/tcp/5001 \
-       --subgraph-name your-subgraph
+       --subgraph-name <YOUR-SUBGRAPH>
     ```
     _Note: If the Graph Node you are deploying to requires authorization,
     make sure to authorize with the node using e.g. `graph auth http://127.0.0.`:8020 <ACCESS_TOKEN>`
@@ -120,9 +120,9 @@ Remove a subgraph from the [Graph Node](https://github.com/graphprotocol/graph-n
 ```sh
 graph \
   remove \
-  --api-key <key> \
+  --api-key <KEY> \
   --node http://127.0.0.1:8020/ \
-  --subgraph-name <your-subgraph>
+  --subgraph-name <YOUR-SUBGRAPH>
 ```
 ## License
 


### PR DESCRIPTION
Updates to README:
  - Include `deploy` and remove in list of commands. 
  - Change step 8 to `yarn build`, step 9 already describes `deploy.`
  - Update `How It Works` bullet formatting to be cleaner and more readable.
  - Mention deployment to node in `How It Works.`
  - Use <> to mark arguments in sample commands that should be replaced by user values.
  - Recommend using `yarn` for generation and building rather than `npm`