### PR TITLE
codegen: Copy-paste `Entity` constructor into codegen'ed ones

### DIFF
--- a/src/codegen/schema.js
+++ b/src/codegen/schema.js
@@ -77,8 +77,8 @@ module.exports = class SchemaCodeGenerator {
       [tsCodegen.param('id', tsCodegen.namedType('string'))],
       undefined,
       `
+      this.entries = new Array(0)
       this.set('id', Value.fromString(id))
-      return this
       `
     )
   }


### PR DESCRIPTION
Fixes https://github.com/graphprotocol/graph-node/issues/600 for good. We should release `0.5.1` for this.