### PR TITLE
Codegen for Tuple types

### DIFF
--- a/src/codegen/types/conversions.js
+++ b/src/codegen/types/conversions.js
@@ -43,6 +43,10 @@ const ETHEREUM_VALUE_TO_ASSEMBLYSCRIPT = [
     code => `${code}.toBigIntArray()`,
   ],
   [/^string\[([0-9]+)?\]$/, 'Array<String>', code => `${code}.toStringArray()`],
+
+  // Tuple
+
+  ['tuple', 'Tuple', code => `${code}.toTuple()`]
 ]
 
 /**
@@ -124,6 +128,7 @@ const ASSEMBLYSCRIPT_TO_ETHEREUM_VALUE = [
     /^string\[([0-9]+)?\]$/,
     code => `EthereumValue.fromStringArray(${code})`,
   ],
+  ['Tuple', 'tuple', code => `EthereumValue.fromTuple(${code})`]
 ]
 
 /**

--- a/src/codegen/typescript.js
+++ b/src/codegen/typescript.js
@@ -108,6 +108,11 @@ class NamedType {
     return this.name
   }
 
+  capitalize()  {
+    this.name = this.name.charAt(0).toUpperCase() + this.name.slice(1)
+    return this
+  }
+
   isPrimitive() {
    let primitives = ["boolean", "u8", "i8", "u16", "i16", "u32", 
                      "i32", "u64", "i64", "f32", "f64", "usize", "isize"]


### PR DESCRIPTION
A part of the Tuple/Struct support epic: 

This PR adds support for Tuple types in `graph codegen`:
- Update event types code generation to create a class for each Tuple type and to use them in the Tuple param method generation.
- In smart contract class, add support for generating call methods that use Tuples as input or output. 