### PR TITLE
Fix graph-ts version for the apiVersion bump to > 0.5.1 as intended

### DIFF
--- a/src/migrations/bump-mapping-api-version.js
+++ b/src/migrations/bump-mapping-api-version.js
@@ -34,7 +34,7 @@ module.exports = {
     let manifest = yaml.safeLoad(fs.readFileSync(manifestFile, 'utf-8'))
     return (
       // Only migrate if the graph-ts version is > 0.5.1...
-      semver.gt(graphTsVersion, '0.5.0') &&
+      semver.gt(graphTsVersion, '0.5.1') &&
       // ...and we have a manifest with mapping > apiVersion = 0.0.1
       manifest &&
       typeof manifest === 'object' &&


### PR DESCRIPTION
@leodasvacas I couldn't find your comment on the PR anymore, but you spotted this correctly and I just realized `0.5.0` was wrong.