### PR TITLE
Change naming of event params classes

### DIFF
--- a/src/codegen/abi.js
+++ b/src/codegen/abi.js
@@ -53,7 +53,7 @@ module.exports = class AbiCodeGenerator {
         let tupleClasses = []
 
         // First, generate a class with the param getters
-        let paramsClassName = eventClassName + 'Params'
+        let paramsClassName = eventClassName + '__Params'
         let paramsClass = tsCodegen.klass(paramsClassName, { export: true })
         paramsClass.addMember(tsCodegen.klassMember('_event', eventClassName))
         paramsClass.addMethod(


### PR DESCRIPTION
The previous name was causing conflicts. Resolves #168.