### PR TITLE
make keytar an optional dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,11 +15,13 @@
     "ipfs-http-client": "^28.1.2",
     "jayson": "^2.0.6",
     "js-yaml": "^3.12.0",
-    "keytar": "^4.3.0",
     "node-fetch": "^2.3.0",
     "pkginfo": "^0.4.1",
     "prettier": "^1.13.5",
     "request": "^2.88.0"
+  },
+  "optionalDependencies": {
+    "keytar": "^4.3.0"
   },
   "bin": {
     "graph": "bin/graph"

--- a/src/command-helpers/auth.js
+++ b/src/command-helpers/auth.js
@@ -1,6 +1,19 @@
-const keytar = require('keytar')
 const toolbox = require('gluegun/toolbox')
 const { normalizeNodeUrl } = require('./node')
+
+// keytar is listed as an optional dependency in package.json and
+// dynamically required in this function
+const requireKeytar = () => {
+  try {
+    return require('keytar')
+  } catch (e) {
+    throw new Error(
+      `require(keytar) failed: ${e.message}. on linux, this is often` +
+        `because of a missing libsecret dependency — try installing` +
+        `libsecret and reinstalling graph-cli.`,
+    )
+  }
+}
 
 const identifyAccessToken = async (node, accessToken) => {
   // Determine the access token to use, if any:
@@ -10,25 +23,26 @@ const identifyAccessToken = async (node, accessToken) => {
     return accessToken
   } else {
     try {
+      const keytar = requireKeytar()
       node = normalizeNodeUrl(node)
       return await keytar.getPassword('graphprotocol-auth', node)
     } catch (e) {
       if (process.platform === 'win32') {
         toolbox.print.warning(
-          `Could not get access token from Windows Credential Vault: ${e.message}`
+          `Could not get access token from Windows Credential Vault: ${e.message}`,
         )
       } else if (process.platform === 'darwin') {
         toolbox.print.warning(
-          `Could not get access token from macOS Keychain: ${e.message}`
+          `Could not get access token from macOS Keychain: ${e.message}`,
         )
       } else if (process.platform === 'linux') {
         toolbox.print.warning(
           `Could not get access token from libsecret ` +
-            `(usually gnome-keyring or ksecretservice): ${e.message}`
+            `(usually gnome-keyring or ksecretservice): ${e.message}`,
         )
       } else {
         toolbox.print.warning(
-          `Could not get access token from OS secret storage service: ${e.message}`
+          `Could not get access token from OS secret storage service: ${e.message}`,
         )
       }
       toolbox.print.info(`Continuing without an access token\n`)
@@ -36,6 +50,28 @@ const identifyAccessToken = async (node, accessToken) => {
   }
 }
 
+const saveAccessToken = async (node, accessToken) => {
+  try {
+    const keytar = requireKeytar()
+    node = normalizeNodeUrl(node)
+    await keytar.setPassword('graphprotocol-auth', node, accessToken)
+  } catch (e) {
+    if (process.platform === 'win32') {
+      throw new Error(`Error storing access token in Windows Credential Vault: ${e}`)
+    } else if (process.platform === 'darwin') {
+      throw new Error(`Error storing access token in macOS Keychain: ${e}`)
+    } else if (process.platform === 'linux') {
+      throw new Error(
+        `Error storing access token with libsecret ` +
+          `(usually gnome-keyring or ksecretservice): ${e}`,
+      )
+    } else {
+      throw new Error(`Error storing access token in OS secret storage service: ${e}`)
+    }
+  }
+}
+
 module.exports = {
   identifyAccessToken,
+  saveAccessToken,
 }

--- a/src/commands/auth.js
+++ b/src/commands/auth.js
@@ -1,6 +1,6 @@
 const chalk = require('chalk')
-const keytar = require('keytar')
 const { validateNodeUrl, normalizeNodeUrl } = require('../command-helpers/node')
+const { saveAccessToken } = require('../command-helpers/auth')
 
 const HELP = `
 ${chalk.bold('graph auth')} [options] ${chalk.bold('<node>')} ${chalk.bold(
@@ -58,22 +58,10 @@ module.exports = {
     }
 
     try {
-      node = normalizeNodeUrl(node)
-      await keytar.setPassword('graphprotocol-auth', node, accessToken)
+      await saveAccessToken(node, accessToken)
       print.success(`Access token set for ${node}`)
     } catch (e) {
-      if (process.platform === 'win32') {
-        print.error(`Error storing access token in Windows Credential Vault: ${e}`)
-      } else if (process.platform === 'darwin') {
-        print.error(`Error storing access token in macOS Keychain: ${e}`)
-      } else if (process.platform === 'linux') {
-        print.error(
-          `Error storing access token with libsecret ` +
-            `(usually gnome-keyring or ksecretservice): ${e}`
-        )
-      } else {
-        print.error(`Error storing access token in OS secret storage service: ${e}`)
-      }
+      print.error(e)
       process.exitCode = 1
     }
   },

--- a/src/commands/create.js
+++ b/src/commands/create.js
@@ -1,5 +1,4 @@
 const chalk = require('chalk')
-const keytar = require('keytar')
 const { validateNodeUrl } = require('../command-helpers/node')
 const { identifyAccessToken } = require('../command-helpers/auth')
 const { createJsonRpcClient } = require('../command-helpers/jsonrpc')

--- a/src/commands/remove.js
+++ b/src/commands/remove.js
@@ -1,5 +1,4 @@
 const chalk = require('chalk')
-const keytar = require('keytar')
 const { validateNodeUrl } = require('../command-helpers/node')
 const { identifyAccessToken } = require('../command-helpers/auth')
 const { createJsonRpcClient } = require('../command-helpers/jsonrpc')


### PR DESCRIPTION
it's sort of a shame to have all projects that make use of graph-cli
require libsecret when it's not necessary in the vast majority of cases.
this commit makes it an optional dependency and doesn't attempt to load
it until it's needed.

i don't anticipate this being a major problem - most of the time this
auth store is being used, it's in a desktop environment where libsecret
will already be present. conversely, most of the time libsecret is
absent it will be in a CI environment of some sort, where it's likely
not needed.