### PR TITLE
Do not add calls with no outputs.

### DIFF
--- a/src/codegen/abi.js
+++ b/src/codegen/abi.js
@@ -330,8 +330,9 @@ module.exports = class AbiCodeGenerator {
     let functions = this.abi.data.filter(
       member =>
         member.get('type') === 'function' &&
-        (member.get('stateMutability') === 'view' ||
-          member.get('stateMutability') === 'pure'),
+          member.get('outputs', immutable.List()).size !== 0 &&
+            (member.get('stateMutability') === 'view' ||
+              member.get('stateMutability') === 'pure'),
     )
 
     // Disambiguate functions with duplicate names


### PR DESCRIPTION
I ran into an issue while trying to run codegen for this contract: 

https://github.com/melonproject/protocol/blob/master/src/contracts/fund/policies/PolicyManager.sol#L67-L73

Now, I am not sure why this is marked public in the first place and I am also not the author of this code but it was causing errors in the code generator due to having 0 outputs.

Thinking about it further, I can think we can safely ignore calls with no outputs :-P.