### PR TITLE
Allow stateMutability 'nonpayable' in generated functions.

### DIFF
--- a/src/codegen/abi.js
+++ b/src/codegen/abi.js
@@ -327,13 +327,12 @@ module.exports = class AbiCodeGenerator {
     )
 
     // Get view/pure functions from the contract
+    let allowedMutability = ['view', 'pure', 'nonpayable', 'constant'];
     let functions = this.abi.data.filter(
       member =>
         member.get('type') === 'function' &&
           member.get('outputs', immutable.List()).size !== 0 &&
-            (member.get('stateMutability') === 'view' ||
-              member.get('stateMutability') === 'pure' ||
-                member.get('stateMutability') === 'nonpayable'),
+            allowedMutability.indexOf(member.get('stateMutability')) !== -1,
     )
 
     // Disambiguate functions with duplicate names

--- a/src/codegen/abi.js
+++ b/src/codegen/abi.js
@@ -332,7 +332,8 @@ module.exports = class AbiCodeGenerator {
         member.get('type') === 'function' &&
           member.get('outputs', immutable.List()).size !== 0 &&
             (member.get('stateMutability') === 'view' ||
-              member.get('stateMutability') === 'pure'),
+              member.get('stateMutability') === 'pure' ||
+                member.get('stateMutability') === 'nonpayable'),
     )
 
     // Disambiguate functions with duplicate names


### PR DESCRIPTION
I ran into several contracts and calls that are not explicitly marked as pure/view but do not modify state, e.g.: https://github.com/melonproject/protocol/blob/master/src/contracts/fund/accounting/Accounting.sol#L138

Is there a compelling reason not to generate these functions? Would it break something down the line? Otherwise I think the filter is a bit too restrictive.