### PR TITLE
compiler: Turn on AS optimizations

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -230,7 +230,7 @@ class Compiler {
       global = path.relative(baseDir, global)
 
       asc.main(
-        [inputFile, global, '--baseDir', baseDir, '--lib', libs, '--outFile', outputFile],
+        [inputFile, global, '--baseDir', baseDir, '--lib', libs, '--outFile', outputFile, '--optimize'],
         {
           stdout: process.stdout,
           stderr: process.stdout,
@@ -283,7 +283,7 @@ class Compiler {
       global = path.relative(baseDir, global)
 
       asc.main(
-        [inputFile, global, '--baseDir', baseDir, '--lib', libs, '--outFile', outputFile],
+        [inputFile, global, '--baseDir', baseDir, '--lib', libs, '--outFile', outputFile, '--optimize'],
         {
           stdout: process.stdout,
           stderr: process.stdout,


### PR DESCRIPTION
Resolves #271. Compilation got a bit slower but its still fast. I still got precise line numbers in errors. I didn't measure massive timing improvements, maybe something like 30%. Seems worth turning this on unconditionally.