### PR TITLE
Add support for Tuple arrays (ABIEncoderV2)

### DIFF
--- a/src/codegen/abi.js
+++ b/src/codegen/abi.js
@@ -377,7 +377,7 @@ module.exports = class AbiCodeGenerator {
                       this.abi.name,
                       '',
                     ).name
-                  : output.get('type').substring(0, 6) === 'tuple['
+                  : util.isTupleArrayType(output.get('type'))
                   ? `Array<${
                       this._generateTupleType(
                         output,
@@ -431,7 +431,7 @@ module.exports = class AbiCodeGenerator {
 
         // Create types for Tuple outputs
         outputs.forEach((output, index) => {
-          if (output.get('type').substring(0, 5) === 'tuple') {
+          if (util.containsTupleType(output.get('type'))) {
             types = types.concat(
               this._generateTupleType(
                 output,
@@ -450,7 +450,7 @@ module.exports = class AbiCodeGenerator {
         returnType = tsCodegen.namedType(returnType.name)
       } else {
         let type = outputs.get(0).get('type')
-        if (type.substring(0, 5) === 'tuple') {
+        if (util.containsTupleType(type)) {
           // Add the Tuple type to the types we'll create
           let tuple = this._generateTupleType(
             outputs.get(0),
@@ -481,7 +481,7 @@ module.exports = class AbiCodeGenerator {
 
       // Create types for Tuple inputs
       inputs.forEach((input, index) => {
-        if (input.get('type').substring(0, 5) === 'tuple') {
+        if (util.containsTupleType(input.get('type'))) {
           types = types.concat(
             this._generateTupleType(
               input,
@@ -510,7 +510,7 @@ module.exports = class AbiCodeGenerator {
                     this.abi.name,
                     '',
                   ).name
-                : input.get('type').substring(0, 6) === 'tuple['
+                : util.isTupleArrayType(input.get('type'))
                 ? `Array<${
                     this._generateTupleType(input, index, tupleInputParentType, '').name
                   }>`
@@ -540,10 +540,7 @@ module.exports = class AbiCodeGenerator {
               ? typesCodegen.ethereumValueToAsc(
                   'result[0]',
                   outputs.get(0).get('type'),
-                  outputs
-                    .get(0)
-                    .get('type')
-                    .substring(0, 6) === 'tuple['
+                  util.isTupleArrayType(outputs.get(0).get('type'))
                     ? this._generateTupleType(
                         outputs.get(0),
                         0,

--- a/src/codegen/abi.js
+++ b/src/codegen/abi.js
@@ -377,7 +377,7 @@ module.exports = class AbiCodeGenerator {
                       this.abi.name,
                       '',
                     ).name
-                  : output.get('type') === 'tuple[]'
+                  : output.get('type').substring(0,6) === 'tuple['
                   ? `Array<${this._generateTupleType(
                       output,
                       index,
@@ -429,7 +429,7 @@ module.exports = class AbiCodeGenerator {
 
         // Create types for Tuple outputs
         outputs.forEach((output, index) => {
-          if (['tuple','tuple[]'].includes(output.get('type'))) {
+          if (output.get('type').substring(0,5) === 'tuple') {
             types = types.concat(
               this._generateTupleType(
                 output,
@@ -448,7 +448,7 @@ module.exports = class AbiCodeGenerator {
         returnType = tsCodegen.namedType(returnType.name)
       } else {
         let type = outputs.get(0).get('type')
-        if (['tuple','tuple[]'].includes(type)) {
+        if (type.substring(0,5) === 'tuple') {
           // Add the Tuple type to the types we'll create
           let tuple = this._generateTupleType(
             outputs.get(0),
@@ -476,7 +476,7 @@ module.exports = class AbiCodeGenerator {
 
       // Create types for Tuple inputs
       inputs.forEach((input, index) => {
-        if (['tuple','tuple[]'].includes(input.get('type'))) {
+        if (input.get('type').substring(0,5) === 'tuple') {
           types = types.concat(
             this._generateTupleType(
               input,
@@ -505,7 +505,7 @@ module.exports = class AbiCodeGenerator {
                     this.abi.name,
                     '',
                   ).name
-                : input.get('type') === 'tuple[]'
+                : input.get('type').substring(0,6) === 'tuple['
                 ? `Array<${this._generateTupleType(
                     input,
                     index,
@@ -538,7 +538,7 @@ module.exports = class AbiCodeGenerator {
               ? typesCodegen.ethereumValueToAsc(
                 'result[0]', 
                 outputs.get(0).get('type'), 
-                outputs.get(0).get('type')==='tuple[]' 
+                outputs.get(0).get('type').substring(0,6) === 'tuple[' 
                   ? this._generateTupleType(
                       outputs.get(0),
                       0,

--- a/src/codegen/abi.js
+++ b/src/codegen/abi.js
@@ -377,14 +377,16 @@ module.exports = class AbiCodeGenerator {
                       this.abi.name,
                       '',
                     ).name
-                  : output.get('type').substring(0,6) === 'tuple['
-                  ? `Array<${this._generateTupleType(
-                      output,
-                      index,
-                      tupleResultParentType,
-                      this.abi.name,
-                      '',
-                    ).name}>`
+                  : output.get('type').substring(0, 6) === 'tuple['
+                  ? `Array<${
+                      this._generateTupleType(
+                        output,
+                        index,
+                        tupleResultParentType,
+                        this.abi.name,
+                        '',
+                      ).name
+                    }>`
                   : typesCodegen.ascTypeForEthereum(output.get('type')),
               ),
             ),
@@ -429,7 +431,7 @@ module.exports = class AbiCodeGenerator {
 
         // Create types for Tuple outputs
         outputs.forEach((output, index) => {
-          if (output.get('type').substring(0,5) === 'tuple') {
+          if (output.get('type').substring(0, 5) === 'tuple') {
             types = types.concat(
               this._generateTupleType(
                 output,
@@ -448,7 +450,7 @@ module.exports = class AbiCodeGenerator {
         returnType = tsCodegen.namedType(returnType.name)
       } else {
         let type = outputs.get(0).get('type')
-        if (type.substring(0,5) === 'tuple') {
+        if (type.substring(0, 5) === 'tuple') {
           // Add the Tuple type to the types we'll create
           let tuple = this._generateTupleType(
             outputs.get(0),
@@ -458,7 +460,10 @@ module.exports = class AbiCodeGenerator {
             this.abi.name,
           )
           types = types.concat(tuple.classes)
-          returnType = type === 'tuple' ? tsCodegen.namedType(tuple.name) : `Array<${tsCodegen.namedType(tuple.name)}>`
+          returnType =
+            type === 'tuple'
+              ? tsCodegen.namedType(tuple.name)
+              : `Array<${tsCodegen.namedType(tuple.name)}>`
         } else {
           returnType = tsCodegen.namedType(typesCodegen.ascTypeForEthereum(type))
         }
@@ -476,7 +481,7 @@ module.exports = class AbiCodeGenerator {
 
       // Create types for Tuple inputs
       inputs.forEach((input, index) => {
-        if (input.get('type').substring(0,5) === 'tuple') {
+        if (input.get('type').substring(0, 5) === 'tuple') {
           types = types.concat(
             this._generateTupleType(
               input,
@@ -505,13 +510,10 @@ module.exports = class AbiCodeGenerator {
                     this.abi.name,
                     '',
                   ).name
-                : input.get('type').substring(0,6) === 'tuple['
-                ? `Array<${this._generateTupleType(
-                    input,
-                    index,
-                    tupleInputParentType,
-                    '',
-                ).name}>`
+                : input.get('type').substring(0, 6) === 'tuple['
+                ? `Array<${
+                    this._generateTupleType(input, index, tupleInputParentType, '').name
+                  }>`
                 : typesCodegen.ascTypeForEthereum(input.get('type')),
             ),
           ),
@@ -536,18 +538,21 @@ module.exports = class AbiCodeGenerator {
           return ${
             simpleReturnType
               ? typesCodegen.ethereumValueToAsc(
-                'result[0]', 
-                outputs.get(0).get('type'), 
-                outputs.get(0).get('type').substring(0,6) === 'tuple[' 
-                  ? this._generateTupleType(
-                      outputs.get(0),
-                      0,
-                      tupleResultParentType,
-                      this.abi.name,
-                      ''
-                    ).name 
-                  : ''
-              )
+                  'result[0]',
+                  outputs.get(0).get('type'),
+                  outputs
+                    .get(0)
+                    .get('type')
+                    .substring(0, 6) === 'tuple['
+                    ? this._generateTupleType(
+                        outputs.get(0),
+                        0,
+                        tupleResultParentType,
+                        this.abi.name,
+                        '',
+                      ).name
+                    : '',
+                )
               : `new ${returnType.name}(
                   ${outputs
                     .map(

--- a/src/codegen/types/conversions.js
+++ b/src/codegen/types/conversions.js
@@ -44,9 +44,10 @@ const ETHEREUM_VALUE_TO_ASSEMBLYSCRIPT = [
   ],
   [/^string\[([0-9]+)?\]$/, 'Array<string>', code => `${code}.toStringArray()`],
 
-  // Tuple
+  // Tuples
 
   ['tuple', 'EthereumTuple', code => `${code}.toTuple()`],
+  [/^tuple\[([0-9]+)?\]$/, 'Array<EthereumTuple>', code => `${code}.toTupleArray()`],
 ]
 
 /**
@@ -135,6 +136,7 @@ const ASSEMBLYSCRIPT_TO_ETHEREUM_VALUE = [
     code => `EthereumValue.fromStringArray(${code})`,
   ],
   ['Tuple', 'tuple', code => `EthereumValue.fromTuple(${code})`],
+  ['Array<Tuple>', /^tuple\[([0-9]+)?\]$/, code => `EthereumValue.fromTupleArray(${code})`],
 ]
 
 /**

--- a/src/codegen/types/conversions.js
+++ b/src/codegen/types/conversions.js
@@ -47,7 +47,7 @@ const ETHEREUM_VALUE_TO_ASSEMBLYSCRIPT = [
   // Tuples
 
   ['tuple', 'EthereumTuple', code => `${code}.toTuple()`],
-  [/^tuple\[([0-9]+)?\]$/, 'Array<EthereumTuple>', code => `${code}.toTupleArray()`],
+  [/^tuple\[([0-9]+)?\]$/, 'Array<EthereumTuple>', (code, type) => `${code}.toTupleArray<${type}>()`],
 ]
 
 /**

--- a/src/codegen/types/index.js
+++ b/src/codegen/types/index.js
@@ -79,9 +79,10 @@ const ascTypeForEthereum = ethereumType =>
 const ethereumTypeForAsc = ascType =>
   findConversionFromType('AssemblyScript', 'EthereumValue', ascType).getIn(['to', 'type'])
 
-const ethereumValueToAsc = (code, ethereumType) =>
+const ethereumValueToAsc = (code, ethereumType, internalType) =>
   findConversionFromType('EthereumValue', 'AssemblyScript', ethereumType).get('convert')(
     code,
+    internalType
   )
 
 const ethereumValueFromAsc = (code, ethereumType) =>

--- a/src/codegen/util.js
+++ b/src/codegen/util.js
@@ -13,6 +13,14 @@ const disambiguateNames = ({ values, getName, setName }) => {
   })
 }
 
+const containsTupleType = t => {
+  return t === 'tuple' || t.match(/^tuple\[([0-9]+)?\]$/)
+}
+
+const isTupleArrayType = t => {
+  return t.match(/^tuple\[([0-9]+)?\]$/)
+}
+
 const unrollTuple = ({ path, index, value }) =>
   value.components.reduce((acc, component, index) => {
     let name = component.name || `value${index}`
@@ -28,6 +36,8 @@ const unrollTuple = ({ path, index, value }) =>
   }, [])
 
 module.exports = {
+  containsTupleType,
   disambiguateNames,
+  isTupleArrayType,
   unrollTuple,
 }


### PR DESCRIPTION
Resolves #316 
Requires [graph-ts #72](https://github.com/graphprotocol/graph-ts/pull/73)

This PR adds support for generating types from Tuple array type params in the ABI.  The conversion methods from a Tuple array `EthereumValue` is the first conversion method we have that uses a generic type, so it requires special casing in `ethereumValueToAsc`. 


----
_Note: This PR is currently in the draft state because it is has not completed sufficient testing_
It is being tested with subgraphs that have an ABI with a Tuple array type as a:
  - [x] call method param 
  - [x] contract method param
  - [x] event param 
