### PR TITLE
Support an optional startBlock field on data sources

### DIFF
--- a/manifest-schema.graphql
+++ b/manifest-schema.graphql
@@ -1,5 +1,6 @@
 scalar String
 scalar File
+scalar BigInt
 
 type Schema {
   file: File!
@@ -19,6 +20,7 @@ type EthereumContractDataSource {
 type EthereumContractSource {
   address: String
   abi: String!
+  startBlock: BigInt
 }
 
 type EthereumContractMapping {

--- a/src/validation/manifest.js
+++ b/src/validation/manifest.js
@@ -147,6 +147,16 @@ const validators = immutable.fromJS({
           },
         ]),
 
+  BigInt: (value, ctx) =>
+    typeof value === 'number'
+      ? List()
+      : immutable.fromJS([
+        {
+          path: ctx.get('path'),
+          message: `Expected BigInt, found ${typeName(value)}:\n${toYAML(value)}`,
+        },
+      ]),
+
   File: (value, ctx) =>
     typeof value === 'string'
       ? require('fs').existsSync(ctx.get('resolveFile')(value))


### PR DESCRIPTION
Required to leverage the start block data source filtering during syncing as proposed in `graph-node PR#1262`.

This PR updates manifest validation to process BigInts from the manifest and adds the `startBlock` field to the `EthereumContractSource` type. 

