### PR TITLE
Subgraph composition

### DIFF
--- a/src/codegen/typescript.js
+++ b/src/codegen/typescript.js
@@ -99,6 +99,17 @@ class ClassMember {
   }
 }
 
+class NamedUnionType {
+  constructor(name, types) {
+    this.name = name
+    this.union = new UnionType(types)
+  }
+
+  toString() {
+    return `export type ${this.name} = ${this.union.toString()}`
+  }
+}
+
 class NamedType {
   constructor(name) {
     this.name = name
@@ -114,9 +125,22 @@ class NamedType {
   }
 
   isPrimitive() {
-   let primitives = ["boolean", "u8", "i8", "u16", "i16", "u32", 
-                     "i32", "u64", "i64", "f32", "f64", "usize", "isize"]
-   return primitives.includes(this.name)
+    let primitives = [
+      'boolean',
+      'u8',
+      'i8',
+      'u16',
+      'i16',
+      'u32',
+      'i32',
+      'u64',
+      'i64',
+      'f32',
+      'f64',
+      'usize',
+      'isize',
+    ]
+    return primitives.includes(this.name)
   }
 }
 
@@ -217,6 +241,7 @@ const staticMethod = (name, params, returnType, body) =>
 const klass = (name, options) => new Class(name, options)
 const klassMember = (name, type) => new ClassMember(name, type)
 const unionType = (...types) => new UnionType(types)
+const namedUnionType = (name, ...types) => new NamedUnionType(name, types)
 const nullableType = type => new NullableType(type)
 const moduleImports = (nameOrNames, module) => new ModuleImports(nameOrNames, module)
 
@@ -235,5 +260,6 @@ module.exports = {
   param,
   nullableType,
   unionType,
+  namedUnionType,
   moduleImports,
 }

--- a/src/codegen/typescript.js
+++ b/src/codegen/typescript.js
@@ -99,17 +99,6 @@ class ClassMember {
   }
 }
 
-class NamedUnionType {
-  constructor(name, types) {
-    this.name = name
-    this.union = new UnionType(types)
-  }
-
-  toString() {
-    return `export type ${this.name} = ${this.union.toString()}`
-  }
-}
-
 class NamedType {
   constructor(name) {
     this.name = name
@@ -241,7 +230,6 @@ const staticMethod = (name, params, returnType, body) =>
 const klass = (name, options) => new Class(name, options)
 const klassMember = (name, type) => new ClassMember(name, type)
 const unionType = (...types) => new UnionType(types)
-const namedUnionType = (name, ...types) => new NamedUnionType(name, types)
 const nullableType = type => new NullableType(type)
 const moduleImports = (nameOrNames, module) => new ModuleImports(nameOrNames, module)
 
@@ -260,6 +248,5 @@ module.exports = {
   param,
   nullableType,
   unionType,
-  namedUnionType,
   moduleImports,
 }

--- a/src/subgraph.js
+++ b/src/subgraph.js
@@ -387,21 +387,23 @@ More than one data source named '${name}', data source names must be unique.`,
 
   static validateUniqueTemplateNames(manifest) {
     let names = []
-    return manifest.get('templates', immutable.List()).reduce((errors, template, templateIndex) => {
-      let path = ['templates', templateIndex, 'name']
-      let name = template.get('name')
-      if (names.includes(name)) {
-        errors = errors.push(
-          immutable.fromJS({
-            path,
-            message: `\
+    return manifest
+      .get('templates', immutable.List())
+      .reduce((errors, template, templateIndex) => {
+        let path = ['templates', templateIndex, 'name']
+        let name = template.get('name')
+        if (names.includes(name)) {
+          errors = errors.push(
+            immutable.fromJS({
+              path,
+              message: `\
 More than one template named '${name}', template names must be unique.`,
-          }),
-        )
-      }
-      names.push(name)
-      return errors
-    }, immutable.List())
+            }),
+          )
+        }
+        names.push(name)
+        return errors
+      }, immutable.List())
   }
 
   static dump(manifest) {

--- a/src/validation/schema.js
+++ b/src/validation/schema.js
@@ -504,6 +504,8 @@ const validateTypeHasNoFields = def => {
   return errors
 }
 
+const validateAtLeastOneExtensionField = def => List()
+
 const typeDefinitionValidators = {
   ObjectTypeDefinition: (defs, def) =>
     def.name && def.name.value == '_SubgraphSchema_'
@@ -514,7 +516,7 @@ const typeDefinitionValidators = {
           ...validateEntityFields(defs, def),
           ...validateNoImportsDirective(def),
         ),
-  ObjectTypeExtension: (_defs, _def) => List(),
+  ObjectTypeExtension: (_defs, def) => List.of(...validateAtLeastOneExtensionField(def)),
 }
 
 const validateTypeDefinition = (defs, def) =>

--- a/src/validation/schema.js
+++ b/src/validation/schema.js
@@ -206,10 +206,13 @@ const validateInnerFieldType = (defs, def, field) => {
             directive.arguments.find(argument => argument.name.value == 'types'),
         )
         let type_args = imports.map(imp =>
-          imp.arguments.find(argument => argument.name.value == 'types'),
+          imp.arguments.find(
+            argument =>
+              argument.name.value == 'types' && argument.value.kind == 'ListValue',
+          ),
         )
-        type_args.map(types =>
-          types.map(type =>
+        return type_args.map(arg =>
+          arg.value.values.map(type =>
             type.kind == 'StringValue'
               ? type.value
               : type.kind == 'ObjectValue' &&
@@ -221,8 +224,12 @@ const validateInnerFieldType = (defs, def, field) => {
           ),
         )
       })
-      .flat()
-      .filter(type => type != undefined),
+      .reduce((flattened, types_args) => {
+        return types_args.reduce((flattened, types_arg) => {
+          types_arg.forEach(type => (type ? flattened.push(type) : undefined))
+          return flattened
+        }, [])
+      }, []),
   )
 
   // Check whether the type name is available, otherwise return an error

--- a/src/validation/schema.js
+++ b/src/validation/schema.js
@@ -504,7 +504,7 @@ const validateImportDirectiveArgumentFrom = (def, directive, argument) => {
 const validateImportDirectiveTypes = (def, directive) => {
   let types = directive.arguments.find(argument => argument.name.value == 'types')
   return types
-    ? validateImportDirectiveArgumentTypesIsValid(def, directive, types)
+    ? validateImportDirectiveArgumentTypes(def, directive, types)
     : List([
         immutable.fromJS({
           loc: directive.name.loc,
@@ -517,7 +517,7 @@ const validateImportDirectiveTypes = (def, directive) => {
 const validateImportDirectiveFrom = (def, directive) => {
   let from = directive.arguments.find(argument => argument.name.value == 'from')
   return from
-    ? validateImportDirectiveArgumentFromIsValid(def, directive, from)
+    ? validateImportDirectiveArgumentFrom(def, directive, from)
     : List([
         immutable.fromJS({
           loc: directive.name.loc,

--- a/src/validation/schema.js
+++ b/src/validation/schema.js
@@ -446,7 +446,7 @@ const validateImportDirectiveArgumentTypes = (def, directive, argument) => {
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
-        message: '@import directive argument: `types` must be an list',
+        message: '@import argument: `types` must be an list',
       }),
     )
   }

--- a/src/validation/schema.js
+++ b/src/validation/schema.js
@@ -463,7 +463,7 @@ const validateImportDirectiveArgumentFrom = (def, directive, argument) => {
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
-        message: `@import directive argument: 'from' must be an object`,
+        message: `@import argument: 'from' must be an object`,
       }),
     )
   }

--- a/src/validation/schema.js
+++ b/src/validation/schema.js
@@ -38,6 +38,8 @@ const TYPE_SUGGESTIONS = [
   ],
 ]
 
+const SUBGRAPH_SCHEMA = '_SubgraphSchema_'
+
 /**
  * Returns a GraphQL type suggestion for a given input type.
  * Returns `undefined` if no suggestion is available for the type.
@@ -169,7 +171,7 @@ const gatherForeignTypes = defs =>
     .filter(
       def =>
         def.kind === 'ObjectTypeDefinition' &&
-        def.name.value == '_SubgraphSchema_' &&
+        def.name.value == SUBGRAPH_SCHEMA &&
         def.directives.find(
           directive =>
             directive.name.value == 'imports' &&
@@ -381,7 +383,7 @@ const validateNoImportsDirective = def =>
         immutable.fromJS({
           loc: def.name.loc,
           entity: def.name.value,
-          message: '@imports directive only allowed on `_SubgraphSchema_` type',
+          message: `@imports directive only allowed on '${SUBGRAPH_SCHEMA}' type`,
         }),
       )
     : List()
@@ -503,7 +505,7 @@ const validateImportDirective = (def, directive) => {
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
-        message: '_SubgraphSchema_ directives: only @import directives allowed',
+        message: `${SUBGRAPH_SCHEMA} directives: only @import directives allowed`,
       }),
     )
   }
@@ -561,7 +563,7 @@ const validateAtLeastOneExtensionField = def => List()
 
 const typeDefinitionValidators = {
   ObjectTypeDefinition: (defs, def) =>
-    def.name && def.name.value == '_SubgraphSchema_'
+    def.name && def.name.value == SUBGRAPH_SCHEMA
       ? List.of(...validateSubgraphSchemaDirectives(def), ...validateTypeHasNoFields(def))
       : List.of(
           ...validateEntityDirective(def),

--- a/src/validation/schema.js
+++ b/src/validation/schema.js
@@ -584,9 +584,10 @@ const validateTypeDefinitions = defs =>
   defs.reduce((errors, def) => errors.concat(validateTypeDefinition(defs, def)), List())
 
 const validateNamingCollisionsInTypes = types => {
-  let memo = Set()
+  let seen = Set()
+  let errored = Set()
   return types.reduce((errors, type) => {
-    if (memo.has(type)) {
+    if (seen.has(type) && !errored.has(type)) {
       errors = errors.push(
         immutable.fromJS({
           loc: { start: 1, end: 1 },
@@ -594,8 +595,10 @@ const validateNamingCollisionsInTypes = types => {
           message: `Type ${type} is defined more than once`,
         }),
       )
+      errored = errored.add(type)
+    } else {
+      seen = seen.add(type)
     }
-    memo = memo.add(type)
     return errors
   }, List())
 }

--- a/src/validation/schema.js
+++ b/src/validation/schema.js
@@ -473,7 +473,7 @@ const validateImportDirectiveArgumentFrom = (def, directive, argument) => {
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
-        message: `@import directive argument: 'from' must have one field of id or name`,
+        message: '@import argument: `from` must have an `id` or `name` field',
       }),
     )
   }

--- a/src/validation/schema.js
+++ b/src/validation/schema.js
@@ -446,7 +446,7 @@ const validateImportDirectiveArgumentTypes = (def, directive, argument) => {
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
-        message: `@import argument: 'types' must be an list`,
+        message: `@import argument 'types' must be an list`,
       }),
     )
   }
@@ -463,7 +463,7 @@ const validateImportDirectiveArgumentFrom = (def, directive, argument) => {
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
-        message: `@import argument: 'from' must be an object`,
+        message: `@import argument 'from' must be an object`,
       }),
     )
   }
@@ -473,7 +473,7 @@ const validateImportDirectiveArgumentFrom = (def, directive, argument) => {
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
-        message: `@import argument: 'from' must have an 'id' or 'name' field`,
+        message: `@import argument 'from' must have an 'id' or 'name' field`,
       }),
     )
   }
@@ -484,7 +484,7 @@ const validateImportDirectiveArgumentFrom = (def, directive, argument) => {
         immutable.fromJS({
           loc: field.name.loc,
           entity: def.name.value,
-          message: `@import argument: 'from' must be one of { name: "Name" } or { id: "ID" }`,
+          message: `@import argument 'from' must be one of { name: "Name" } or { id: "ID" }`,
         }),
       )
     }
@@ -493,7 +493,7 @@ const validateImportDirectiveArgumentFrom = (def, directive, argument) => {
         immutable.fromJS({
           loc: field.name.loc,
           entity: def.name.value,
-          message: `@import argument: 'from' must be one of { name: "Name" } or { id: "ID" } with string values`,
+          message: `@import argument 'from' must be one of { name: "Name" } or { id: "ID" } with string values`,
         }),
       )
     }
@@ -533,7 +533,7 @@ const validateImportDirectiveName = directive =>
         immutable.fromJS({
           loc: directive.name.loc,
           entity: def.name.value,
-          message: `${RESERVED_TYPE} directives: only @import directives allowed`,
+          message: `${RESERVED_TYPE} directives only allows @import directives`,
         }),
       ])
     : List()

--- a/src/validation/schema.js
+++ b/src/validation/schema.js
@@ -399,7 +399,7 @@ const importDirectiveTypeValidators = {
           loc: directive.name.loc,
           entity: def.name.value,
           message:
-            'Imported type must be one of "Name", { name: "Name" }, or { name: "Name", as: "Alias" }',
+            'Import must be one of "Name" or { name: "Name", as: "Alias" }',
         }),
       )
     }
@@ -435,7 +435,7 @@ const validateImportDirectiveType = (def, directive, type) => {
           loc: directive.name.loc,
           entity: def.name.value,
           message:
-            'Imported type must be one of "Name", { name: "Name" }, or { name: "Name", as: "Alias" }',
+            'Import must be one of "Name" or { name: "Name", as: "Alias" }',
         }),
       )
 }

--- a/src/validation/schema.js
+++ b/src/validation/schema.js
@@ -440,7 +440,7 @@ const validateImportDirectiveType = (def, directive, type) => {
       )
 }
 
-const validateImportDirectiveArgumentTypesIsValid = (def, directive, argument) => {
+const validateImportDirectiveArgumentTypes = (def, directive, argument) => {
   if (argument.value.kind != 'ListValue') {
     return List().push(
       immutable.fromJS({

--- a/src/validation/schema.js
+++ b/src/validation/schema.js
@@ -398,7 +398,7 @@ const importDirectiveTypeValidators = {
         immutable.fromJS({
           loc: directive.name.loc,
           entity: def.name.value,
-          message: '@imports type objects accept and require two fields: [name, as]',
+          message: 'Imported type must be one of "Name", { name: "Name" }, or { name: "Name", as: "Alias" }',
         }),
       )
     }
@@ -433,7 +433,7 @@ const validateImportDirectiveType = (def, directive, type) =>
         immutable.fromJS({
           loc: directive.name.loc,
           entity: def.name.value,
-          message: 'Imported type must be either String | {name: String, as: String}',
+          message: 'Imported type must be one of "Name", { name: "Name" }, or { name: "Name", as: "Alias" }',
         }),
       )
 
@@ -443,7 +443,7 @@ const validateImportDirectiveArgumentTypesIsValid = (def, directive, argument) =
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
-        message: '@imports directive argument: types must be an list',
+        message: '@imports directive argument: `types` must be an list',
       }),
     )
   }
@@ -481,7 +481,7 @@ const validateImportDirectiveArgumentFromIsValid = (def, directive, argument) =>
         immutable.fromJS({
           loc: field.name.loc,
           entity: def.name.value,
-          message: `@imports directive from: only fields 'id' or 'name' allowed`,
+          message: `@imports directive argument: 'from' must be one of { name: "Name" } or { id: "ID" }`,
         }),
       )
     }
@@ -584,9 +584,9 @@ const validateTypeDefinitions = defs =>
 
 const validateNamingCollisionsInTypes = types => {
   let seen = Set()
-  let errored = Set()
+  let conflicting = Set()
   return types.reduce((errors, type) => {
-    if (seen.has(type) && !errored.has(type)) {
+    if (seen.has(type) && !conflicting.has(type)) {
       errors = errors.push(
         immutable.fromJS({
           loc: { start: 1, end: 1 },
@@ -594,7 +594,7 @@ const validateNamingCollisionsInTypes = types => {
           message: `Type ${type} is defined more than once`,
         }),
       )
-      errored = errored.add(type)
+      conflicting = conflicting.add(type)
     } else {
       seen = seen.add(type)
     }
@@ -602,8 +602,7 @@ const validateNamingCollisionsInTypes = types => {
   }, List())
 }
 
-const validateNamingCollisions = (local, foreign) =>
-  List.of(...validateNamingCollisionsInTypes(local.concat(foreign)))
+const validateNamingCollisions = (local, foreign) => validateNamingCollisionsInTypes(local.concat(foreign))
 
 const validateSchema = filename => {
   let doc = loadSchema(filename)

--- a/src/validation/schema.js
+++ b/src/validation/schema.js
@@ -548,13 +548,13 @@ const validateSubgraphSchemaDirectives = def =>
 
 const validateTypeHasNoFields = def =>
   def.fields.length
-    ? List[
+    ? List([
         immutable.fromJS({
           loc: def.name.loc,
           entity: def.name.value,
           message: `${def.name.value} type is not allowed any fields by convention`,
-        })
-      ]
+        }),
+      ])
     : List()
 
 const validateAtLeastOneExtensionField = def => List()

--- a/src/validation/schema.js
+++ b/src/validation/schema.js
@@ -409,7 +409,7 @@ const importDirectiveTypeValidators = {
           immutable.fromJS({
             loc: directive.name.loc,
             entity: def.name.value,
-            message: `@import type object field '${field.name.value}' invalid,  may only be one of: [name, as]`,
+            message: `@import field '${field.name.value}' invalid, may only be one of: [name, as]`,
           }),
         )
       }

--- a/src/validation/schema.js
+++ b/src/validation/schema.js
@@ -167,7 +167,7 @@ const gatherLocalTypes = defs =>
     )
     .map(def => def.name.value)
 
-const gatherForeignTypes = defs =>
+const gatherImportedTypes = defs =>
   defs
     .filter(
       def =>
@@ -243,7 +243,7 @@ const validateInnerFieldType = (defs, def, field) => {
   let availableTypes = List.of(
     ...BUILTIN_SCALAR_TYPES,
     ...gatherLocalTypes(defs),
-    ...gatherForeignTypes(defs),
+    ...gatherImportedTypes(defs),
   )
 
   // Check whether the type name is available, otherwise return an error
@@ -615,7 +615,7 @@ const validateSchema = filename => {
     ...validateTypeDefinitions(schema.definitions),
     ...validateNamingCollisions(
       gatherLocalTypes(schema.definitions),
-      gatherForeignTypes(schema.definitions),
+      gatherImportedTypes(schema.definitions),
     ),
   )
 }

--- a/src/validation/schema.js
+++ b/src/validation/schema.js
@@ -470,7 +470,7 @@ const validateImportDirectiveArgumentFromIsValid = (def, directive, argument) =>
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
-        message: '@imports directive argument: `from` must have one field of [id, name]',
+        message: `@imports directive argument: 'from' must have one field of id or name`,
       }),
     )
   }
@@ -481,7 +481,7 @@ const validateImportDirectiveArgumentFromIsValid = (def, directive, argument) =>
         immutable.fromJS({
           loc: field.name.loc,
           entity: def.name.value,
-          message: '@imports directive from: only fields `id` or `name` allowed',
+          message: `@imports directive from: only fields 'id' or 'name' allowed`,
         }),
       )
     }

--- a/src/validation/schema.js
+++ b/src/validation/schema.js
@@ -38,8 +38,8 @@ const TYPE_SUGGESTIONS = [
   ],
 ]
 
-// As a convention, the type _schema_ is reserved to define imports on.
-const RESERVED_TYPE = '_schema_'
+// As a convention, the type _Schema_ is reserved to define imports on.
+const RESERVED_TYPE = '_Schema_'
 
 /**
  * Returns a GraphQL type suggestion for a given input type.

--- a/src/validation/schema.js
+++ b/src/validation/schema.js
@@ -175,7 +175,7 @@ const gatherImportedTypes = defs =>
         def.name.value == RESERVED_TYPE &&
         def.directives.find(
           directive =>
-            directive.name.value == 'imports' &&
+            directive.name.value == 'import' &&
             directive.arguments.find(argument => argument.name.value == 'types'),
         ),
     )
@@ -183,7 +183,7 @@ const gatherImportedTypes = defs =>
       def.directives
         .filter(
           directive =>
-            directive.name.value == 'imports' &&
+            directive.name.value == 'import' &&
             directive.arguments.find(argument => argument.name.value == 'types'),
         )
         .map(imp =>
@@ -378,13 +378,13 @@ const validateEntityFields = (defs, def) =>
     List(),
   )
 
-const validateNoImportsDirective = def =>
-  def.directives.find(directive => directive.name.value == 'imports')
+const validateNoImportDirective = def =>
+  def.directives.find(directive => directive.name.value == 'import')
     ? List().push(
         immutable.fromJS({
           loc: def.name.loc,
           entity: def.name.value,
-          message: `@imports directive only allowed on '${RESERVED_TYPE}' type`,
+          message: `@import directive only allowed on '${RESERVED_TYPE}' type`,
         }),
       )
     : List()
@@ -409,7 +409,7 @@ const importDirectiveTypeValidators = {
           immutable.fromJS({
             loc: directive.name.loc,
             entity: def.name.value,
-            message: `@imports type object field '${field.name.value}' invalid,  may only be one of: [name, as]`,
+            message: `@import type object field '${field.name.value}' invalid,  may only be one of: [name, as]`,
           }),
         )
       }
@@ -418,7 +418,7 @@ const importDirectiveTypeValidators = {
           immutable.fromJS({
             loc: directive.name.loc,
             entity: def.name.value,
-            message: '@imports type object fields [name, as] must be strings',
+            message: '@import type object fields [name, as] must be strings',
           }),
         )
       }
@@ -446,7 +446,7 @@ const validateImportDirectiveArgumentTypesIsValid = (def, directive, argument) =
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
-        message: '@imports directive argument: `types` must be an list',
+        message: '@import directive argument: `types` must be an list',
       }),
     )
   }
@@ -463,7 +463,7 @@ const validateImportDirectiveArgumentFromIsValid = (def, directive, argument) =>
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
-        message: '@imports directive argument: `from` must be an object',
+        message: '@import directive argument: `from` must be an object',
       }),
     )
   }
@@ -473,7 +473,7 @@ const validateImportDirectiveArgumentFromIsValid = (def, directive, argument) =>
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
-        message: `@imports directive argument: 'from' must have one field of id or name`,
+        message: `@import directive argument: 'from' must have one field of id or name`,
       }),
     )
   }
@@ -484,7 +484,7 @@ const validateImportDirectiveArgumentFromIsValid = (def, directive, argument) =>
         immutable.fromJS({
           loc: field.name.loc,
           entity: def.name.value,
-          message: `@imports directive argument: 'from' must be one of { name: "Name" } or { id: "ID" }`,
+          message: `@import directive argument: 'from' must be one of { name: "Name" } or { id: "ID" }`,
         }),
       )
     }
@@ -493,7 +493,7 @@ const validateImportDirectiveArgumentFromIsValid = (def, directive, argument) =>
         immutable.fromJS({
           loc: field.name.loc,
           entity: def.name.value,
-          message: '@imports directive from: fields must have string values',
+          message: '@import directive from: fields must have string values',
         }),
       )
     }
@@ -528,7 +528,7 @@ const validateImportDirectiveFrom = (def, directive) => {
 }
 
 const validateImportDirectiveName = directive =>
-  directive.name.value != 'imports'
+  directive.name.value != 'import'
     ? List([
         immutable.fromJS({
           loc: directive.name.loc,
@@ -572,7 +572,7 @@ const typeDefinitionValidators = {
           ...validateEntityDirective(def),
           ...validateEntityID(def),
           ...validateEntityFields(defs, def),
-          ...validateNoImportsDirective(def),
+          ...validateNoImportDirective(def),
         ),
   ObjectTypeExtension: (_defs, def) => validateAtLeastOneExtensionField(def),
 }

--- a/src/validation/schema.js
+++ b/src/validation/schema.js
@@ -457,7 +457,7 @@ const validateImportDirectiveArgumentTypes = (def, directive, argument) => {
   )
 }
 
-const validateImportDirectiveArgumentFromIsValid = (def, directive, argument) => {
+const validateImportDirectiveArgumentFrom = (def, directive, argument) => {
   if (argument.value.kind != 'ObjectValue') {
     return List().push(
       immutable.fromJS({

--- a/src/validation/schema.js
+++ b/src/validation/schema.js
@@ -546,19 +546,16 @@ const validateSubgraphSchemaDirectives = def =>
     List(),
   )
 
-const validateTypeHasNoFields = def => {
-  let errors = List()
-  if (def.fields.length) {
-    return errors.push(
-      immutable.fromJS({
-        loc: def.name.loc,
-        entity: def.name.value,
-        message: `${def.name.value} type is not allowed any fields by convention`,
-      }),
-    )
-  }
-  return errors
-}
+const validateTypeHasNoFields = def =>
+  def.fields.length
+    ? List[
+        immutable.fromJS({
+          loc: def.name.loc,
+          entity: def.name.value,
+          message: `${def.name.value} type is not allowed any fields by convention`,
+        })
+      ]
+    : List()
 
 const validateAtLeastOneExtensionField = def => List()
 

--- a/src/validation/schema.js
+++ b/src/validation/schema.js
@@ -399,7 +399,7 @@ const importDirectiveTypeValidators = {
           loc: directive.name.loc,
           entity: def.name.value,
           message:
-            'Import must be one of "Name" or { name: "Name", as: "Alias" }',
+            `Import must be one of "Name" or { name: "Name", as: "Alias" }`,
         }),
       )
     }
@@ -418,7 +418,7 @@ const importDirectiveTypeValidators = {
           immutable.fromJS({
             loc: directive.name.loc,
             entity: def.name.value,
-            message: '@import fields [name, as] must be strings',
+            message: `@import fields [name, as] must be strings`,
           }),
         )
       }
@@ -435,7 +435,7 @@ const validateImportDirectiveType = (def, directive, type) => {
           loc: directive.name.loc,
           entity: def.name.value,
           message:
-            'Import must be one of "Name" or { name: "Name", as: "Alias" }',
+            `Import must be one of "Name" or { name: "Name", as: "Alias" }`,
         }),
       )
 }
@@ -446,7 +446,7 @@ const validateImportDirectiveArgumentTypes = (def, directive, argument) => {
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
-        message: '@import argument: `types` must be an list',
+        message: `@import argument: 'types' must be an list`,
       }),
     )
   }
@@ -463,7 +463,7 @@ const validateImportDirectiveArgumentFrom = (def, directive, argument) => {
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
-        message: '@import directive argument: `from` must be an object',
+        message: `@import directive argument: 'from' must be an object`,
       }),
     )
   }
@@ -473,7 +473,7 @@ const validateImportDirectiveArgumentFrom = (def, directive, argument) => {
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
-        message: '@import argument: `from` must have an `id` or `name` field',
+        message: `@import argument: 'from' must have an 'id' or 'name' field`,
       }),
     )
   }
@@ -594,7 +594,7 @@ const validateNamingCollisionsInTypes = types => {
         immutable.fromJS({
           loc: { start: 1, end: 1 },
           entity: type,
-          message: `Type ${type} is defined more than once`,
+          message: `Type '${type}' is defined more than once`,
         }),
       )
       conflicting = conflicting.add(type)

--- a/src/validation/schema.js
+++ b/src/validation/schema.js
@@ -605,8 +605,8 @@ const validateNamingCollisionsInTypes = types => {
   }, List())
 }
 
-const validateNamingCollisions = (local, foreign) =>
-  validateNamingCollisionsInTypes(local.concat(foreign))
+const validateNamingCollisions = (local, imported) =>
+  validateNamingCollisionsInTypes(local.concat(imported))
 
 const validateSchema = filename => {
   let doc = loadSchema(filename)

--- a/src/validation/schema.js
+++ b/src/validation/schema.js
@@ -418,7 +418,7 @@ const importDirectiveTypeValidators = {
           immutable.fromJS({
             loc: directive.name.loc,
             entity: def.name.value,
-            message: '@import type object fields [name, as] must be strings',
+            message: '@import fields [name, as] must be strings',
           }),
         )
       }

--- a/src/validation/schema.js
+++ b/src/validation/schema.js
@@ -38,6 +38,7 @@ const TYPE_SUGGESTIONS = [
   ],
 ]
 
+// As a convention, the type _SubgraphSchema_ is reserved to define imports on.
 const SUBGRAPH_SCHEMA = '_SubgraphSchema_'
 
 /**

--- a/src/validation/schema.js
+++ b/src/validation/schema.js
@@ -484,7 +484,7 @@ const validateImportDirectiveArgumentFrom = (def, directive, argument) => {
         immutable.fromJS({
           loc: field.name.loc,
           entity: def.name.value,
-          message: `@import directive argument: 'from' must be one of { name: "Name" } or { id: "ID" }`,
+          message: `@import argument: 'from' must be one of { name: "Name" } or { id: "ID" }`,
         }),
       )
     }
@@ -522,7 +522,7 @@ const validateImportDirectiveFrom = (def, directive) => {
         immutable.fromJS({
           loc: directive.name.loc,
           entity: def.name.value,
-          message: `@import argument 'from' required: specify the subgraph to import types from`,
+          message: `@import argument 'from' must be specified`,
         }),
       ])
 }

--- a/src/validation/schema.js
+++ b/src/validation/schema.js
@@ -493,7 +493,7 @@ const validateImportDirectiveArgumentFrom = (def, directive, argument) => {
         immutable.fromJS({
           loc: field.name.loc,
           entity: def.name.value,
-          message: `@import argument: 'from' fields must have string values`,
+          message: `@import argument: 'from' must be one of { name: "Name" } or { id: "ID" } with string values`,
         }),
       )
     }

--- a/src/validation/schema.js
+++ b/src/validation/schema.js
@@ -493,7 +493,7 @@ const validateImportDirectiveArgumentFrom = (def, directive, argument) => {
         immutable.fromJS({
           loc: field.name.loc,
           entity: def.name.value,
-          message: '@import directive from: fields must have string values',
+          message: `@import argument: 'from' fields must have string values`,
         }),
       )
     }

--- a/src/validation/schema.js
+++ b/src/validation/schema.js
@@ -574,7 +574,7 @@ const typeDefinitionValidators = {
           ...validateEntityFields(defs, def),
           ...validateNoImportsDirective(def),
         ),
-  ObjectTypeExtension: (_defs, def) => List.of(...validateAtLeastOneExtensionField(def)),
+  ObjectTypeExtension: (_defs, def) => validateAtLeastOneExtensionField(def),
 }
 
 const validateTypeDefinition = (defs, def) =>


### PR DESCRIPTION
This PR adds support for `@imports` directives which allow subgraphs to imports types from other subgraphs. 

Ideally `@import` directives would be available at the top level of a schema document, but top level directives are not yet available. Relevant issues:

https://github.com/graphql/graphql-spec/issues/410
https://github.com/graphql/graphql-spec/pull/556
https://github.com/Urigo/graphql-import/issues/89

As a convention, the type `_SubgraphSchema_` is reserved exclusively to define `@import` directives. Once top level directives are supported in GraphQL, we can remove this convention and provide a migration script for `_SubgraphSchema_` defined imports.

