### PR TITLE
Check for mismatches between ABI and generated code at build time

### DIFF
--- a/src/type-generator.js
+++ b/src/type-generator.js
@@ -173,6 +173,11 @@ module.exports = class TypeGenerator {
       let code = prettier.format(
         [
           GENERATED_FILE_NOTE,
+          `\
+// @abiName ${abi.abi.name}
+// @abiFile ${abi.abi.file}
+// @abiHash ${abi.abi.hash}
+`,
           ...codeGenerator.generateModuleImports(),
           ...codeGenerator.generateTypes(),
         ].join('\n'),
@@ -208,6 +213,11 @@ module.exports = class TypeGenerator {
       let code = prettier.format(
         [
           GENERATED_FILE_NOTE,
+          `\
+// @abiName ${abi.abi.name}
+// @abiFile ${abi.abi.file}
+// @abiHash ${abi.abi.hash}
+`,
           ...codeGenerator.generateModuleImports(),
           ...codeGenerator.generateTypes(),
         ].join('\n'),


### PR DESCRIPTION
This is still considered work in progress. I think the checks may be too strict. This is what this PR does:

1. ABI name, file and hash meta data is added to all generated files.
2. During builds, all source files imported by mappings, directly or indirectly, are collected.
3. All generated files in the imported sources are checked for whether
    1. an ABI with the same name is included in the data source the mapping is for,
    2. this ABI has the same content hash as the ABI the code was generated for.

This ensures that no mapping uses code that was generated for either an ABI that doesn't exist in the data source or an ABI that is "incompatible" (= not identical) to the ABI with the same name in the data source.

Unfortunately, we can't check whether an imported file is actually _used_ (thanks to the good old halting problem), so this check would force subgraph developers to split up their files more rigorously to avoid any cross-data-source imports in shared files. That's why I think these checks may be too strict. We could make them log warnings rather than failing the subgraph build.

Any thoughts?

The errors look like this:
```
✖ Failed to compile subgraph: Failed to compile data source:
Mapping source files and ABIs do not match:
- Data source 'Reputation': Code generated for ABI 'GenesisProtocol' 
  (src/types/GenesisProtocol/GenesisProtocol.ts) is used in the mapping but does
  not match the ABI with the same name (abis/0.0.1-rc.23/GenesisProtocol.json).
```

_Note: I'll add tests if and when we agree that this feature is something we want._