### PR TITLE
Fulltext directive validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
   },
   "scripts": {
     "test": "jest --verbose",
+    "test:init": "jest tests/cli/init.test.js --verbose",
+    "test:validation": "jest tests/cli/validation.test.js --verbose",
     "release:patch": "npm version patch && npm publish && git push origin master && git push --tags",
     "release:minor": "npm version minor && npm publish && git push origin master && git push --tags"
   }

--- a/src/subgraph.js
+++ b/src/subgraph.js
@@ -60,22 +60,29 @@ module.exports = class Subgraph {
 
     if (errors.size > 0) {
       errors = errors.groupBy(error => error.get('entity')).sort()
+      let msg = errors.reduce((msg, errors, entity) => {
+        errors = errors.groupBy(error => error.get('directive'))
+        let inner_msgs = errors.reduce((msg, errors, directive) => {
+          return `${msg}${directive ? `
 
-      let msg = errors.reduce(
-        (msg, errors, entity) =>
-          `${msg}
+      ${directive}:` : ''}
+    ${errors
+      .map(error =>
+        error
+          .get('message')
+          .split('\n')
+          .join('\n    '),
+      )
+      .map(msg => `${directive ? '  ' : ''}- ${msg}`)
+      .join('\n    ')}`}
+            ,
+          ``,
+          )
+          return `${msg}
 
-  ${entity}:
-  ${errors
-    .map(error =>
-      error
-        .get('message')
-        .split('\n')
-        .join('\n    '),
-    )
-    .map(msg => `- ${msg}`)
-    .join('\n  ')}`,
-        `Error in ${path.relative(process.cwd(), filename)}:`,
+    ${entity}:${inner_msgs}`
+        },
+        `Error in ${path.relative(process.cwd(), filename)}:`
       )
 
       throw new Error(msg)

--- a/src/subgraph.js
+++ b/src/subgraph.js
@@ -63,27 +63,26 @@ module.exports = class Subgraph {
       let msg = errors.reduce((msg, errors, entity) => {
         errors = errors.groupBy(error => error.get('directive'))
         let inner_msgs = errors.reduce((msg, errors, directive) => {
-          return `${msg}${directive ? `
+          return `${msg}${
+            directive
+              ? `
+    ${directive}:`
+              : ''
+          }
+  ${errors
+    .map(error =>
+      error
+        .get('message')
+        .split('\n')
+        .join('\n  '),
+    )
+    .map(msg => `${directive ? '  ' : ''}- ${msg}`)
+    .join('\n  ')}`
+        }, ``)
+        return `${msg}
 
-      ${directive}:` : ''}
-    ${errors
-      .map(error =>
-        error
-          .get('message')
-          .split('\n')
-          .join('\n    '),
-      )
-      .map(msg => `${directive ? '  ' : ''}- ${msg}`)
-      .join('\n    ')}`}
-            ,
-          ``,
-          )
-          return `${msg}
-
-    ${entity}:${inner_msgs}`
-        },
-        `Error in ${path.relative(process.cwd(), filename)}:`
-      )
+  ${entity}:${inner_msgs}`
+      }, `Error in ${path.relative(process.cwd(), filename)}:`)
 
       throw new Error(msg)
     }

--- a/src/validation/schema.js
+++ b/src/validation/schema.js
@@ -390,12 +390,12 @@ const validateNoImportDirective = def =>
     : List()
 
 const validateNoFullTextDirective = def =>
-  def.directives.find(directive => directive.name.value == 'fullText')
+  def.directives.find(directive => directive.name.value == 'fulltext')
     ? List().push(
         immutable.fromJS({
           loc: def.name.loc,
           entity: def.name.value,
-          message: `@fullText directive only allowed on '${RESERVED_TYPE}' type`,
+          message: `@fulltext directive only allowed on '${RESERVED_TYPE}' type`,
         }),
       )
     : List()
@@ -409,7 +409,7 @@ const validateFullTextDirectiveFields = (def, directive) => {
             immutable.fromJS({
               loc: directive.name.loc,
               entity: def.name.value,
-              message: `found invalid argument: '${argument.name.value}', @fullText directives only allow 'name','language', 'algorithm', and 'includes' arguments`,
+              message: `found invalid argument: '${argument.name.value}', @fulltext directives only allow 'name','language', 'algorithm', and 'includes' arguments`,
             }),
           ]),
     )
@@ -424,7 +424,7 @@ const validateFullTextDirectiveName = (def, directive) => {
         immutable.fromJS({
           loc: directive.name.loc,
           entity: def.name.value,
-          message: `@fullText argument 'name' must be specified`,
+          message: `@fulltext argument 'name' must be specified`,
         }),
       ])
 }
@@ -435,7 +435,7 @@ const validateFullTextDirectiveArgumentName = (def, directive, argument) => {
         immutable.fromJS({
           loc: directive.name.loc,
           entity: def.name.value,
-          message: `@fullText argument 'name' must be a string`,
+          message: `@fulltext argument 'name' must be a string`,
         }),
       )
     : List([])
@@ -449,7 +449,7 @@ const validateFullTextDirectiveLanguage = (def, directive) => {
         immutable.fromJS({
           loc: directive.name.loc,
           entity: def.name.value,
-          message: `@fullText argument 'language' must be specified`,
+          message: `@fulltext argument 'language' must be specified`,
         }),
       ])
 }
@@ -460,7 +460,7 @@ const validateFullTextDirectiveArgumentLanguage = (def, directive, argument) => 
         immutable.fromJS({
           loc: directive.name.loc,
           entity: def.name.value,
-          message: `@fullText argument 'language' must be a string`,
+          message: `@fulltext argument 'language' must be a string`,
         }),
       )
     : List([])
@@ -474,7 +474,7 @@ const validateFullTextDirectiveAlgorithm = (def, directive) => {
         immutable.fromJS({
           loc: directive.name.loc,
           entity: def.name.value,
-          message: `@fullText argument 'algorithm' must be specified`,
+          message: `@fulltext argument 'algorithm' must be specified`,
         }),
       ])
 }
@@ -485,7 +485,7 @@ const validateFullTextDirectiveArgumentAlgorithm = (def, directive, argument) =>
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
-        message: `@fullText argument 'algorithm' must be an enum`,
+        message: `@fulltext argument 'algorithm' must be an enum`,
       }),
     )
   } else if (!['ranked', 'proximityRank'].includes(argument.value.value)) {
@@ -493,7 +493,7 @@ const validateFullTextDirectiveArgumentAlgorithm = (def, directive, argument) =>
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
-        message: `@fullText 'algorithm' value, '${argument.value.value}', is not a variant of the _FullTextAlgorithm enum`,
+        message: `@fulltext 'algorithm' value, '${argument.value.value}', is not a variant of the _FullTextAlgorithm enum`,
       }),
     )
   } else {
@@ -509,7 +509,7 @@ const validateFullTextDirectiveInclude = (def, directive) => {
         immutable.fromJS({
           loc: directive.name.loc,
           entity: def.name.value,
-          message: `@fullText argument 'include' must be a list`,
+          message: `@fulltext argument 'include' must be a list`,
         }),
       )
     }
@@ -523,7 +523,7 @@ const validateFullTextDirectiveInclude = (def, directive) => {
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
-        message: `@fullText argument 'include' must be specified`,
+        message: `@fulltext argument 'include' must be specified`,
       }),
     ])
   }
@@ -535,7 +535,7 @@ const validateFullTextDirectiveArgumentInclude = (def, directive, argument) => {
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
-        message: `@fullText argument 'include' must be an object`,
+        message: `@fulltext argument 'include' must be an object`,
       }),
     )
   }
@@ -610,7 +610,7 @@ const validateFulltextDirectiveArgumentIncludeArgumentFieldsObjects = (
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
-        message: `@fullText argument 'include' entity fields items must be objects`,
+        message: `@fulltext argument 'include' entity fields items must be objects`,
       }),
     )
   } else {
@@ -841,14 +841,14 @@ const validateFullTextDirective = (def, directive) =>
 const validateSubgraphSchemaDirective = (def, directive) => {
   if (directive.name.value == 'import') {
     return validateImportDirective(def, directive)
-  } else if (directive.name.value == 'fullText') {
+  } else if (directive.name.value == 'fulltext') {
     return validateFullTextDirective(def, directive)
   } else {
     return List([
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
-        message: `${RESERVED_TYPE} type only allows @import and @fullText directives`,
+        message: `${RESERVED_TYPE} type only allows @import and @fulltext directives`,
       }),
     ])
   }

--- a/src/validation/schema.js
+++ b/src/validation/schema.js
@@ -625,15 +625,6 @@ const validateFulltextDirectiveArgumentIncludeArgumentFieldsObjects = (
       }),
     )
   } else {
-    if (argument.fields.length != 2) {
-      return List().push(
-        immutable.fromJS({
-          loc: directive.name.loc,
-          entity: def.name.value,
-          message: `@fulltext include argument fields objects must include, 'name' and 'weight' fields}`,
-        }),
-      )
-    }
     return argument.fields.reduce(
       (errors, field) =>
         errors.concat(
@@ -653,12 +644,12 @@ const validateFulltextDirectiveArgumentIncludeArgumentFieldsObject = (
   directive,
   field,
 ) => {
-  if (!['name', 'weight'].includes(field.name.value)) {
+  if (!['name'].includes(field.name.value)) {
     return List([]).push(
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
-        message: `@fulltext field '${field.name.value}' invalid, may only be one of: [name, weight]`,
+        message: `@fulltext field '${field.name.value}' invalid, may only be one of: [name]`,
       }),
     )
   } else if (field.name.value == 'name' && field.value.kind != 'StringValue') {
@@ -667,22 +658,6 @@ const validateFulltextDirectiveArgumentIncludeArgumentFieldsObject = (
         loc: directive.name.loc,
         entity: def.name.value,
         message: `@fulltext include field 'name' must be a string`,
-      }),
-    )
-  } else if (field.name.value == 'weight' && field.value.kind != 'EnumValue') {
-    return List([]).push(
-      immutable.fromJS({
-        loc: directive.name.loc,
-        entity: def.name.value,
-        message: `@fulltext include field 'weight' must be an Enum`,
-      }),
-    )
-  } else if (field.name.value == 'weight' && !['A', 'B', 'C', 'D'].includes(field.value.value)) {
-    return List().push(
-      immutable.fromJS({
-        loc: directive.name.loc,
-        entity: def.name.value,
-        message: `@fulltext 'weight' value, '${field.value.value}', is not a variant of the _FullTextWeight enum`,
       }),
     )
   } else {

--- a/src/validation/schema.js
+++ b/src/validation/schema.js
@@ -455,7 +455,7 @@ const validateFulltextDirectiveLanguage = (def, directive) => {
 }
 
 const validateFulltextDirectiveArgumentLanguage = (def, directive, argument) => {
-  let languages = ['SIMPLE','DA','NL','EN','FI','FR','DE','HU','IT','NO','PT','RO','RU','ES','SV','TR']
+  let languages = ['simple','da','nl','en','fi','fr','de','hu','it','no','pt','ro','ru','es','sv','tr']
   if (argument.value.kind != 'EnumValue') {
     return List().push(
       immutable.fromJS({
@@ -499,7 +499,7 @@ const validateFulltextDirectiveArgumentAlgorithm = (def, directive, argument) =>
         message: `@fulltext argument 'algorithm' must be an enum`,
       }),
     )
-  } else if (!['RANKED', 'PROXIMITY_RANK'].includes(argument.value.value)) {
+  } else if (!['ranked', 'proximity_rank'].includes(argument.value.value)) {
     return List().push(
       immutable.fromJS({
         loc: directive.name.loc,

--- a/src/validation/schema.js
+++ b/src/validation/schema.js
@@ -455,15 +455,26 @@ const validateFullTextDirectiveLanguage = (def, directive) => {
 }
 
 const validateFullTextDirectiveArgumentLanguage = (def, directive, argument) => {
-  return argument.value.kind != 'StringValue'
-    ? List().push(
-        immutable.fromJS({
-          loc: directive.name.loc,
-          entity: def.name.value,
-          message: `@fulltext argument 'language' must be a string`,
-        }),
-      )
-    : List([])
+  let languages = ['SIMPLE','DANISH','DUTCH','ENGLISH','FINNISH','FRENCH','GERMAN','HUNGARIAN','ITALIAN','NORWEGIAN','PORTUGUESE','ROMANIAN','RUSSIAN','SPANISH','SWEDISH','TURKISH']
+  if (argument.value.kind != 'EnumValue') {
+    return List().push(
+      immutable.fromJS({
+        loc: directive.name.loc,
+        entity: def.name.value,
+        message: `@fulltext argument 'language' must be a string`,
+      }),
+    )
+  } else if (!languages.includes(argument.value.value)) {
+    return List().push(
+      immutable.fromJS({
+        loc: directive.name.loc,
+        entity: def.name.value,
+        message: `@fulltext 'language' value is not a variant of the _FullTextLanguage enum`,
+      }),
+    )
+  } else {
+    return List([])
+  }
 }
 
 const validateFullTextDirectiveAlgorithm = (def, directive) => {
@@ -658,16 +669,25 @@ const validateFulltextDirectiveArgumentIncludeArgumentFieldsObject = (
         message: `@fulltext include field 'name' must be a string`,
       }),
     )
-  } else if (field.name.value == 'weight' && field.value.kind != 'IntValue') {
+  } else if (field.name.value == 'weight' && field.value.kind != 'EnumValue') {
     return List([]).push(
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
-        message: `@fulltext include field 'weight' must be an int`,
+        message: `@fulltext include field 'weight' must be an Enum`,
       }),
     )
+  } else if (field.name.value == 'weight' && !['A', 'B', 'C', 'D'].includes(field.value.value)) {
+    return List().push(
+      immutable.fromJS({
+        loc: directive.name.loc,
+        entity: def.name.value,
+        message: `@fulltext 'weight' value, '${field.value.value}', is not a variant of the _FullTextWeight enum`,
+      }),
+    )
+  } else {
+    return List([])
   }
-  return List([])
 }
 
 const importDirectiveTypeValidators = {

--- a/src/validation/schema.js
+++ b/src/validation/schema.js
@@ -389,7 +389,7 @@ const validateNoImportDirective = def =>
       )
     : List()
 
-const validateNoFullTextDirective = def =>
+const validateNoFulltextDirective = def =>
   def.directives.find(directive => directive.name.value == 'fulltext')
     ? List().push(
         immutable.fromJS({
@@ -400,7 +400,7 @@ const validateNoFullTextDirective = def =>
       )
     : List()
 
-const validateFullTextDirectiveFields = (def, directive) => {
+const validateFulltextDirectiveFields = (def, directive) => {
   return directive.arguments.reduce((errors, argument) => {
     return errors.concat(
       ['name', 'language', 'algorithm', 'include'].includes(argument.name.value)
@@ -416,10 +416,10 @@ const validateFullTextDirectiveFields = (def, directive) => {
   }, List([]))
 }
 
-const validateFullTextDirectiveName = (def, directive) => {
+const validateFulltextDirectiveName = (def, directive) => {
   let name = directive.arguments.find(argument => argument.name.value == 'name')
   return name
-    ? validateFullTextDirectiveArgumentName(def, directive, name)
+    ? validateFulltextDirectiveArgumentName(def, directive, name)
     : List([
         immutable.fromJS({
           loc: directive.name.loc,
@@ -429,7 +429,7 @@ const validateFullTextDirectiveName = (def, directive) => {
       ])
 }
 
-const validateFullTextDirectiveArgumentName = (def, directive, argument) => {
+const validateFulltextDirectiveArgumentName = (def, directive, argument) => {
   return argument.value.kind != 'StringValue'
     ? List().push(
         immutable.fromJS({
@@ -441,10 +441,10 @@ const validateFullTextDirectiveArgumentName = (def, directive, argument) => {
     : List([])
 }
 
-const validateFullTextDirectiveLanguage = (def, directive) => {
+const validateFulltextDirectiveLanguage = (def, directive) => {
   let language = directive.arguments.find(argument => argument.name.value == 'language')
   return language
-    ? validateFullTextDirectiveArgumentLanguage(def, directive, language)
+    ? validateFulltextDirectiveArgumentLanguage(def, directive, language)
     : List([
         immutable.fromJS({
           loc: directive.name.loc,
@@ -454,7 +454,7 @@ const validateFullTextDirectiveLanguage = (def, directive) => {
       ])
 }
 
-const validateFullTextDirectiveArgumentLanguage = (def, directive, argument) => {
+const validateFulltextDirectiveArgumentLanguage = (def, directive, argument) => {
   let languages = ['SIMPLE','DA','NL','EN','FI','FR','DE','HU','IT','NO','PT','RO','RU','ES','SV','TR']
   if (argument.value.kind != 'EnumValue') {
     return List().push(
@@ -469,7 +469,7 @@ const validateFullTextDirectiveArgumentLanguage = (def, directive, argument) => 
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
-        message: `@fulltext 'language' value is not a variant of the _FullTextLanguage enum`,
+        message: `@fulltext 'language' value is not a variant of the _FulltextLanguage enum`,
       }),
     )
   } else {
@@ -477,10 +477,10 @@ const validateFullTextDirectiveArgumentLanguage = (def, directive, argument) => 
   }
 }
 
-const validateFullTextDirectiveAlgorithm = (def, directive) => {
+const validateFulltextDirectiveAlgorithm = (def, directive) => {
   let algorithm = directive.arguments.find(argument => argument.name.value == 'algorithm')
   return algorithm
-    ? validateFullTextDirectiveArgumentAlgorithm(def, directive, algorithm)
+    ? validateFulltextDirectiveArgumentAlgorithm(def, directive, algorithm)
     : List([
         immutable.fromJS({
           loc: directive.name.loc,
@@ -490,7 +490,7 @@ const validateFullTextDirectiveAlgorithm = (def, directive) => {
       ])
 }
 
-const validateFullTextDirectiveArgumentAlgorithm = (def, directive, argument) => {
+const validateFulltextDirectiveArgumentAlgorithm = (def, directive, argument) => {
   if (argument.value.kind != 'EnumValue') {
     return List().push(
       immutable.fromJS({
@@ -504,7 +504,7 @@ const validateFullTextDirectiveArgumentAlgorithm = (def, directive, argument) =>
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
-        message: `@fulltext 'algorithm' value, '${argument.value.value}', is not a variant of the _FullTextAlgorithm enum`,
+        message: `@fulltext 'algorithm' value, '${argument.value.value}', is not a variant of the _FulltextAlgorithm enum`,
       }),
     )
   } else {
@@ -512,7 +512,7 @@ const validateFullTextDirectiveArgumentAlgorithm = (def, directive, argument) =>
   }
 }
 
-const validateFullTextDirectiveInclude = (def, directive) => {
+const validateFulltextDirectiveInclude = (def, directive) => {
   let include = directive.arguments.find(argument => argument.name.value == 'include')
   if (include) {
     if (include.value.kind != 'ListValue') {
@@ -526,7 +526,7 @@ const validateFullTextDirectiveInclude = (def, directive) => {
     }
     return include.value.values.reduce(
       (errors, type) =>
-        errors.concat(validateFullTextDirectiveArgumentInclude(def, directive, type)),
+        errors.concat(validateFulltextDirectiveArgumentInclude(def, directive, type)),
       List(),
     )
   } else {
@@ -540,7 +540,7 @@ const validateFullTextDirectiveInclude = (def, directive) => {
   }
 }
 
-const validateFullTextDirectiveArgumentInclude = (def, directive, argument) => {
+const validateFulltextDirectiveArgumentInclude = (def, directive, argument) => {
   if (argument.kind != 'ObjectValue') {
     return List().push(
       immutable.fromJS({
@@ -824,20 +824,20 @@ const validateImportDirective = (def, directive) =>
     ...validateImportDirectiveFrom(def, directive),
   )
 
-const validateFullTextDirective = (def, directive) =>
+const validateFulltextDirective = (def, directive) =>
   List.of(
-    ...validateFullTextDirectiveFields(def, directive),
-    ...validateFullTextDirectiveName(def, directive),
-    ...validateFullTextDirectiveLanguage(def, directive),
-    ...validateFullTextDirectiveAlgorithm(def, directive),
-    ...validateFullTextDirectiveInclude(def, directive),
+    ...validateFulltextDirectiveFields(def, directive),
+    ...validateFulltextDirectiveName(def, directive),
+    ...validateFulltextDirectiveLanguage(def, directive),
+    ...validateFulltextDirectiveAlgorithm(def, directive),
+    ...validateFulltextDirectiveInclude(def, directive),
   )
 
 const validateSubgraphSchemaDirective = (def, directive) => {
   if (directive.name.value == 'import') {
     return validateImportDirective(def, directive)
   } else if (directive.name.value == 'fulltext') {
-    return validateFullTextDirective(def, directive)
+    return validateFulltextDirective(def, directive)
   } else {
     return List([
       immutable.fromJS({
@@ -877,7 +877,7 @@ const typeDefinitionValidators = {
           ...validateEntityID(def),
           ...validateEntityFields(defs, def),
           ...validateNoImportDirective(def),
-          ...validateNoFullTextDirective(def),
+          ...validateNoFulltextDirective(def),
         ),
   ObjectTypeExtension: (_defs, def) => validateAtLeastOneExtensionField(def),
 }

--- a/src/validation/schema.js
+++ b/src/validation/schema.js
@@ -488,7 +488,7 @@ const validateFullTextDirectiveArgumentAlgorithm = (def, directive, argument) =>
         message: `@fulltext argument 'algorithm' must be an enum`,
       }),
     )
-  } else if (!['ranked', 'proximityRank'].includes(argument.value.value)) {
+  } else if (!['RANKED', 'PROXIMITY_RANK'].includes(argument.value.value)) {
     return List().push(
       immutable.fromJS({
         loc: directive.name.loc,

--- a/src/validation/schema.js
+++ b/src/validation/schema.js
@@ -455,13 +455,13 @@ const validateFullTextDirectiveLanguage = (def, directive) => {
 }
 
 const validateFullTextDirectiveArgumentLanguage = (def, directive, argument) => {
-  let languages = ['SIMPLE','DANISH','DUTCH','ENGLISH','FINNISH','FRENCH','GERMAN','HUNGARIAN','ITALIAN','NORWEGIAN','PORTUGUESE','ROMANIAN','RUSSIAN','SPANISH','SWEDISH','TURKISH']
+  let languages = ['SIMPLE','DA','NL','EN','FI','FR','DE','HU','IT','NO','PT','RO','RU','ES','SV','TR']
   if (argument.value.kind != 'EnumValue') {
     return List().push(
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
-        message: `@fulltext argument 'language' must be a string`,
+        message: `@fulltext argument 'language' must be an enum`,
       }),
     )
   } else if (!languages.includes(argument.value.value)) {

--- a/src/validation/schema.js
+++ b/src/validation/schema.js
@@ -380,27 +380,27 @@ const validateEntityFields = (defs, def) =>
 
 const validateNoImportDirective = def =>
   def.directives.find(directive => directive.name.value == 'import')
-    ? List().push(
+    ? List([
         immutable.fromJS({
           loc: def.name.loc,
           entity: def.name.value,
           message: `@import directive only allowed on '${RESERVED_TYPE}' type`,
         }),
-      )
+      ])
     : List()
 
-const validateNoFulltextDirective = def =>
+const validateNoFulltext = def =>
   def.directives.find(directive => directive.name.value == 'fulltext')
-    ? List().push(
+    ? List([
         immutable.fromJS({
           loc: def.name.loc,
           entity: def.name.value,
           message: `@fulltext directive only allowed on '${RESERVED_TYPE}' type`,
         }),
-      )
+      ])
     : List()
 
-const validateFulltextDirectiveFields = (def, directive) => {
+const validateFulltextFields = (def, directive) => {
   return directive.arguments.reduce((errors, argument) => {
     return errors.concat(
       ['name', 'language', 'algorithm', 'include'].includes(argument.name.value)
@@ -409,17 +409,17 @@ const validateFulltextDirectiveFields = (def, directive) => {
             immutable.fromJS({
               loc: directive.name.loc,
               entity: def.name.value,
-              message: `found invalid argument: '${argument.name.value}', @fulltext directives only allow 'name','language', 'algorithm', and 'includes' arguments`,
+              message: `found invalid argument: '${argument.name.value}', @fulltext directives only allow 'name', 'language', 'algorithm', and 'includes' arguments`,
             }),
           ]),
     )
   }, List([]))
 }
 
-const validateFulltextDirectiveName = (def, directive) => {
+const validateFulltextName = (def, directive) => {
   let name = directive.arguments.find(argument => argument.name.value == 'name')
   return name
-    ? validateFulltextDirectiveArgumentName(def, directive, name)
+    ? validateFulltextArgumentName(def, directive, name)
     : List([
         immutable.fromJS({
           loc: directive.name.loc,
@@ -429,22 +429,22 @@ const validateFulltextDirectiveName = (def, directive) => {
       ])
 }
 
-const validateFulltextDirectiveArgumentName = (def, directive, argument) => {
+const validateFulltextArgumentName = (def, directive, argument) => {
   return argument.value.kind != 'StringValue'
-    ? List().push(
+    ? List([
         immutable.fromJS({
           loc: directive.name.loc,
           entity: def.name.value,
           message: `@fulltext argument 'name' must be a string`,
         }),
-      )
+      ])
     : List([])
 }
 
-const validateFulltextDirectiveLanguage = (def, directive) => {
+const validateFulltextLanguage = (def, directive) => {
   let language = directive.arguments.find(argument => argument.name.value == 'language')
   return language
-    ? validateFulltextDirectiveArgumentLanguage(def, directive, language)
+    ? validateFulltextArgumentLanguage(def, directive, language)
     : List([
         immutable.fromJS({
           loc: directive.name.loc,
@@ -454,33 +454,50 @@ const validateFulltextDirectiveLanguage = (def, directive) => {
       ])
 }
 
-const validateFulltextDirectiveArgumentLanguage = (def, directive, argument) => {
-  let languages = ['simple','da','nl','en','fi','fr','de','hu','it','no','pt','ro','ru','es','sv','tr']
+const validateFulltextArgumentLanguage = (def, directive, argument) => {
+  let languages = [
+    'simple',
+    'da',
+    'nl',
+    'en',
+    'fi',
+    'fr',
+    'de',
+    'hu',
+    'it',
+    'no',
+    'pt',
+    'ro',
+    'ru',
+    'es',
+    'sv',
+    'tr',
+  ]
   if (argument.value.kind != 'EnumValue') {
-    return List().push(
+    return List([
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
-        message: `@fulltext argument 'language' must be an enum`,
+        message: `@fulltext 'language' value must be one of: simple, da, nl, en, fi, fr , de , hu , it , no , pt , ro , ru , es , sv , tr.`,
       }),
-    )
+    ])
   } else if (!languages.includes(argument.value.value)) {
-    return List().push(
+    return List([
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
-        message: `@fulltext 'language' value is not a variant of the _FulltextLanguage enum`,
+        message: `@fulltext 'language' value must be one of: simple, da, nl, en, fi, fr , de , hu , it , no , pt , ro , ru , es , sv , tr.`,
       }),
-    )
+    ])
   } else {
     return List([])
   }
 }
 
-const validateFulltextDirectiveAlgorithm = (def, directive) => {
+const validateFulltextAlgorithm = (def, directive) => {
   let algorithm = directive.arguments.find(argument => argument.name.value == 'algorithm')
   return algorithm
-    ? validateFulltextDirectiveArgumentAlgorithm(def, directive, algorithm)
+    ? validateFulltextArgumentAlgorithm(def, directive, algorithm)
     : List([
         immutable.fromJS({
           loc: directive.name.loc,
@@ -490,43 +507,43 @@ const validateFulltextDirectiveAlgorithm = (def, directive) => {
       ])
 }
 
-const validateFulltextDirectiveArgumentAlgorithm = (def, directive, argument) => {
+const validateFulltextArgumentAlgorithm = (def, directive, argument) => {
   if (argument.value.kind != 'EnumValue') {
-    return List().push(
+    return List([
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
-        message: `@fulltext argument 'algorithm' must be an enum`,
+        message: `@fulltext argument 'algorithm' must be one of: rank, proximityRank`,
       }),
-    )
-  } else if (!['ranked', 'proximity_rank'].includes(argument.value.value)) {
-    return List().push(
+    ])
+  } else if (!['rank', 'proximity_rank'].includes(argument.value.value)) {
+    return List([
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
-        message: `@fulltext 'algorithm' value, '${argument.value.value}', is not a variant of the _FulltextAlgorithm enum`,
+        message: `@fulltext 'algorithm' value, '${argument.value.value}', must be one of: rank, proximityRank`,
       }),
-    )
+    ])
   } else {
     return List([])
   }
 }
 
-const validateFulltextDirectiveInclude = (def, directive) => {
+const validateFulltextInclude = (def, directive) => {
   let include = directive.arguments.find(argument => argument.name.value == 'include')
   if (include) {
     if (include.value.kind != 'ListValue') {
-      return List().push(
+      return List([
         immutable.fromJS({
           loc: directive.name.loc,
           entity: def.name.value,
           message: `@fulltext argument 'include' must be a list`,
         }),
-      )
+      ])
     }
     return include.value.values.reduce(
       (errors, type) =>
-        errors.concat(validateFulltextDirectiveArgumentInclude(def, directive, type)),
+        errors.concat(validateFulltextArgumentInclude(def, directive, type)),
       List(),
     )
   } else {
@@ -540,69 +557,63 @@ const validateFulltextDirectiveInclude = (def, directive) => {
   }
 }
 
-const validateFulltextDirectiveArgumentInclude = (def, directive, argument) => {
+const validateFulltextArgumentInclude = (def, directive, argument) => {
   if (argument.kind != 'ObjectValue') {
-    return List().push(
+    return List([
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
-        message: `@fulltext argument 'include' must be an object`,
+        message: `@fulltext argument 'include' must have the form '[{ entity: "entityName", fields: [{name: "fieldName"},...]}...]`,
       }),
-    )
+    ])
   }
   if (argument.fields.length != 2) {
     return List([
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
-        message: `fulltext include argument must have two fields, 'entity' and 'fields'}`,
+        message: `@fulltext argument include must have two fields, 'entity' and 'fields'}`,
       }),
     ])
   }
   return argument.fields.reduce(
     (errors, field) =>
-      errors.concat(
-        validateFulltextDirectiveArgumentIncludeFields(def, directive, field),
-      ),
+      errors.concat(validateFulltextArgumentIncludeFields(def, directive, field)),
     List([]),
   )
 }
 
-const validateFulltextDirectiveArgumentIncludeFields = (def, directive, field) => {
+const validateFulltextArgumentIncludeFields = (def, directive, field) => {
   if (!['entity', 'fields'].includes(field.name.value)) {
-    return List().push(
+    return List([
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
-        message: `@fulltext field '${field.name.value}' invalid, may only be one of: [entity, fields]`,
+        message: `@fulltext argument 'include > ${field.name.value}' must be be one of: [entity, fields]`,
       }),
-    )
+    ])
   }
   if (field.name.value == 'entity' && field.value.kind != 'StringValue') {
-    return List().push(
+    return List([
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
-        message: `@fulltext include field 'entity' must be a string`,
+        message: `@fulltext argument 'include > entity' must be the name of an entity in the schema enclosed in double quotes`,
       }),
-    )
+    ])
   } else if (field.name.value == 'fields' && field.value.kind != 'ListValue') {
-    return List().push(
+    return List([
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
-        message: `@fulltext entity 'fields' must be Lists`,
+        message: `@fulltext argument 'include > fields' must be a list`,
       }),
-    )
+    ])
   } else if (field.name.value == 'fields' && field.value.kind == 'ListValue') {
     return field.value.values.reduce(
       (errors, field) =>
         errors.concat(
-          validateFulltextDirectiveArgumentIncludeArgumentFieldsObjects(
-            def,
-            directive,
-            field,
-          ),
+          validateFulltextArgumentIncludeFieldsObjects(def, directive, field),
         ),
       List([]),
     )
@@ -611,55 +622,43 @@ const validateFulltextDirectiveArgumentIncludeFields = (def, directive, field) =
   }
 }
 
-const validateFulltextDirectiveArgumentIncludeArgumentFieldsObjects = (
-  def,
-  directive,
-  argument,
-) => {
+const validateFulltextArgumentIncludeFieldsObjects = (def, directive, argument) => {
   if (argument.kind != 'ObjectValue') {
-    return List().push(
+    return List([
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
-        message: `@fulltext argument 'include' entity fields items must be objects`,
+        message: `@fulltext argument 'include > fields' must have the form '[{ name: "fieldName" }, ...]`,
       }),
-    )
+    ])
   } else {
     return argument.fields.reduce(
       (errors, field) =>
         errors.concat(
-          validateFulltextDirectiveArgumentIncludeArgumentFieldsObject(
-            def,
-            directive,
-            field,
-          ),
+          validateFulltextArgumentIncludeArgumentFieldsObject(def, directive, field),
         ),
       List(),
     )
   }
 }
 
-const validateFulltextDirectiveArgumentIncludeArgumentFieldsObject = (
-  def,
-  directive,
-  field,
-) => {
+const validateFulltextArgumentIncludeArgumentFieldsObject = (def, directive, field) => {
   if (!['name'].includes(field.name.value)) {
-    return List([]).push(
+    return List([
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
-        message: `@fulltext field '${field.name.value}' invalid, may only be one of: [name]`,
+        message: `@fulltext argument 'include > fields' has invalid member '${field.name.value}', must be one of: name`,
       }),
-    )
+    ])
   } else if (field.name.value == 'name' && field.value.kind != 'StringValue') {
-    return List([]).push(
+    return List([
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
-        message: `@fulltext include field 'name' must be a string`,
+        message: `@fulltext argument 'include > fields > name' must be the name of an entity field enclosed in double quotes`,
       }),
-    )
+    ])
   } else {
     return List([])
   }
@@ -705,24 +704,24 @@ const importDirectiveTypeValidators = {
 const validateImportDirectiveType = (def, directive, type) => {
   return importDirectiveTypeValidators[type.kind]
     ? importDirectiveTypeValidators[type.kind](def, directive, type)
-    : List().push(
+    : List([
         immutable.fromJS({
           loc: directive.name.loc,
           entity: def.name.value,
           message: `Import must be one of "Name" or { name: "Name", as: "Alias" }`,
         }),
-      )
+      ])
 }
 
 const validateImportDirectiveArgumentTypes = (def, directive, argument) => {
   if (argument.value.kind != 'ListValue') {
-    return List().push(
+    return List([
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
         message: `@import argument 'types' must be an list`,
       }),
-    )
+    ])
   }
 
   return argument.value.values.reduce(
@@ -733,23 +732,23 @@ const validateImportDirectiveArgumentTypes = (def, directive, argument) => {
 
 const validateImportDirectiveArgumentFrom = (def, directive, argument) => {
   if (argument.value.kind != 'ObjectValue') {
-    return List().push(
+    return List([
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
         message: `@import argument 'from' must be an object`,
       }),
-    )
+    ])
   }
 
   if (argument.value.fields.length != 1) {
-    return List().push(
+    return List([
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
         message: `@import argument 'from' must have an 'id' or 'name' field`,
       }),
-    )
+    ])
   }
 
   return argument.value.fields.reduce((errors, field) => {
@@ -824,20 +823,20 @@ const validateImportDirective = (def, directive) =>
     ...validateImportDirectiveFrom(def, directive),
   )
 
-const validateFulltextDirective = (def, directive) =>
+const validateFulltext = (def, directive) =>
   List.of(
-    ...validateFulltextDirectiveFields(def, directive),
-    ...validateFulltextDirectiveName(def, directive),
-    ...validateFulltextDirectiveLanguage(def, directive),
-    ...validateFulltextDirectiveAlgorithm(def, directive),
-    ...validateFulltextDirectiveInclude(def, directive),
+    ...validateFulltextFields(def, directive),
+    ...validateFulltextName(def, directive),
+    ...validateFulltextLanguage(def, directive),
+    ...validateFulltextAlgorithm(def, directive),
+    ...validateFulltextInclude(def, directive),
   )
 
 const validateSubgraphSchemaDirective = (def, directive) => {
   if (directive.name.value == 'import') {
     return validateImportDirective(def, directive)
   } else if (directive.name.value == 'fulltext') {
-    return validateFulltextDirective(def, directive)
+    return validateFulltext(def, directive)
   } else {
     return List([
       immutable.fromJS({
@@ -877,7 +876,7 @@ const typeDefinitionValidators = {
           ...validateEntityID(def),
           ...validateEntityFields(defs, def),
           ...validateNoImportDirective(def),
-          ...validateNoFulltextDirective(def),
+          ...validateNoFulltext(def),
         ),
   ObjectTypeExtension: (_defs, def) => validateAtLeastOneExtensionField(def),
 }

--- a/src/validation/schema.js
+++ b/src/validation/schema.js
@@ -409,6 +409,7 @@ const validateFulltextFields = (def, directive) => {
             immutable.fromJS({
               loc: directive.name.loc,
               entity: def.name.value,
+              directive: fulltextDirectiveName(directive),
               message: `found invalid argument: '${argument.name.value}', @fulltext directives only allow 'name', 'language', 'algorithm', and 'includes' arguments`,
             }),
           ]),
@@ -424,6 +425,7 @@ const validateFulltextName = (def, directive) => {
         immutable.fromJS({
           loc: directive.name.loc,
           entity: def.name.value,
+          directive: fulltextDirectiveName(directive),
           message: `@fulltext argument 'name' must be specified`,
         }),
       ])
@@ -435,10 +437,16 @@ const validateFulltextArgumentName = (def, directive, argument) => {
         immutable.fromJS({
           loc: directive.name.loc,
           entity: def.name.value,
+          directive: fulltextDirectiveName(directive),
           message: `@fulltext argument 'name' must be a string`,
         }),
       ])
     : List([])
+}
+
+const fulltextDirectiveName = (directive) => {
+    let arg = directive.arguments.find(argument => argument.name.value == 'name')
+    return arg ? arg.value.value : "undefinedDirectiveName"
 }
 
 const validateFulltextLanguage = (def, directive) => {
@@ -449,6 +457,7 @@ const validateFulltextLanguage = (def, directive) => {
         immutable.fromJS({
           loc: directive.name.loc,
           entity: def.name.value,
+          directive: fulltextDirectiveName(directive),
           message: `@fulltext argument 'language' must be specified`,
         }),
       ])
@@ -478,7 +487,8 @@ const validateFulltextArgumentLanguage = (def, directive, argument) => {
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
-        message: `@fulltext 'language' value must be one of: simple, da, nl, en, fi, fr , de , hu , it , no , pt , ro , ru , es , sv , tr.`,
+        directive: fulltextDirectiveName(directive),
+        message: `@fulltext 'language' value must be one of: ${languages.join(', ')}`,
       }),
     ])
   } else if (!languages.includes(argument.value.value)) {
@@ -486,7 +496,8 @@ const validateFulltextArgumentLanguage = (def, directive, argument) => {
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
-        message: `@fulltext 'language' value must be one of: simple, da, nl, en, fi, fr , de , hu , it , no , pt , ro , ru , es , sv , tr.`,
+        directive: fulltextDirectiveName(directive),
+        message: `@fulltext directive 'language' value must be one of: ${languages.join(', ')}`,
       }),
     ])
   } else {
@@ -502,6 +513,7 @@ const validateFulltextAlgorithm = (def, directive) => {
         immutable.fromJS({
           loc: directive.name.loc,
           entity: def.name.value,
+          directive: fulltextDirectiveName(directive),
           message: `@fulltext argument 'algorithm' must be specified`,
         }),
       ])
@@ -513,6 +525,7 @@ const validateFulltextArgumentAlgorithm = (def, directive, argument) => {
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
+        directive: fulltextDirectiveName(directive),
         message: `@fulltext argument 'algorithm' must be one of: rank, proximityRank`,
       }),
     ])
@@ -521,6 +534,7 @@ const validateFulltextArgumentAlgorithm = (def, directive, argument) => {
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
+        directive: fulltextDirectiveName(directive),
         message: `@fulltext 'algorithm' value, '${argument.value.value}', must be one of: rank, proximityRank`,
       }),
     ])
@@ -537,6 +551,7 @@ const validateFulltextInclude = (def, directive) => {
         immutable.fromJS({
           loc: directive.name.loc,
           entity: def.name.value,
+          directive: fulltextDirectiveName(directive),
           message: `@fulltext argument 'include' must be a list`,
         }),
       ])
@@ -551,6 +566,7 @@ const validateFulltextInclude = (def, directive) => {
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
+        directive: fulltextDirectiveName(directive),
         message: `@fulltext argument 'include' must be specified`,
       }),
     ])
@@ -563,7 +579,8 @@ const validateFulltextArgumentInclude = (def, directive, argument) => {
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
-        message: `@fulltext argument 'include' must have the form '[{ entity: "entityName", fields: [{name: "fieldName"},...]}...]`,
+        directive: fulltextDirectiveName(directive),
+        message: `@fulltext argument 'include' must have the form '[{entity: "entityName", fields: [{name: "fieldName"},... ]}... ]`,
       }),
     ])
   }
@@ -572,7 +589,8 @@ const validateFulltextArgumentInclude = (def, directive, argument) => {
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
-        message: `@fulltext argument include must have two fields, 'entity' and 'fields'}`,
+        directive: fulltextDirectiveName(directive),
+        message: `@fulltext argument include must have two fields, 'entity' and 'fields'`,
       }),
     ])
   }
@@ -589,7 +607,8 @@ const validateFulltextArgumentIncludeFields = (def, directive, field) => {
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
-        message: `@fulltext argument 'include > ${field.name.value}' must be be one of: [entity, fields]`,
+        directive: fulltextDirectiveName(directive),
+        message: `@fulltext argument 'include > ${field.name.value}' must be be one of: entity, fields`,
       }),
     ])
   }
@@ -598,6 +617,7 @@ const validateFulltextArgumentIncludeFields = (def, directive, field) => {
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
+        directive: fulltextDirectiveName(directive),
         message: `@fulltext argument 'include > entity' must be the name of an entity in the schema enclosed in double quotes`,
       }),
     ])
@@ -606,6 +626,7 @@ const validateFulltextArgumentIncludeFields = (def, directive, field) => {
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
+        directive: fulltextDirectiveName(directive),
         message: `@fulltext argument 'include > fields' must be a list`,
       }),
     ])
@@ -628,6 +649,7 @@ const validateFulltextArgumentIncludeFieldsObjects = (def, directive, argument) 
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
+        directive: fulltextDirectiveName(directive),
         message: `@fulltext argument 'include > fields' must have the form '[{ name: "fieldName" }, ...]`,
       }),
     ])
@@ -648,6 +670,7 @@ const validateFulltextArgumentIncludeArgumentFieldsObject = (def, directive, fie
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
+        directive: fulltextDirectiveName(directive),
         message: `@fulltext argument 'include > fields' has invalid member '${field.name.value}', must be one of: name`,
       }),
     ])
@@ -656,6 +679,7 @@ const validateFulltextArgumentIncludeArgumentFieldsObject = (def, directive, fie
       immutable.fromJS({
         loc: directive.name.loc,
         entity: def.name.value,
+        directive: fulltextDirectiveName(directive),
         message: `@fulltext argument 'include > fields > name' must be the name of an entity field enclosed in double quotes`,
       }),
     ])
@@ -683,7 +707,7 @@ const importDirectiveTypeValidators = {
           immutable.fromJS({
             loc: directive.name.loc,
             entity: def.name.value,
-            message: `@import field '${field.name.value}' invalid, may only be one of: [name, as]`,
+            message: `@import field '${field.name.value}' invalid, may only be one of: name, as`,
           }),
         )
       }

--- a/src/validation/schema.js
+++ b/src/validation/schema.js
@@ -444,9 +444,9 @@ const validateFulltextArgumentName = (def, directive, argument) => {
     : List([])
 }
 
-const fulltextDirectiveName = (directive) => {
-    let arg = directive.arguments.find(argument => argument.name.value == 'name')
-    return arg ? arg.value.value : "undefinedDirectiveName"
+const fulltextDirectiveName = directive => {
+  let arg = directive.arguments.find(argument => argument.name.value == 'name')
+  return arg ? arg.value.value : 'Other'
 }
 
 const validateFulltextLanguage = (def, directive) => {
@@ -497,7 +497,9 @@ const validateFulltextArgumentLanguage = (def, directive, argument) => {
         loc: directive.name.loc,
         entity: def.name.value,
         directive: fulltextDirectiveName(directive),
-        message: `@fulltext directive 'language' value must be one of: ${languages.join(', ')}`,
+        message: `@fulltext directive 'language' value must be one of: ${languages.join(
+          ', ',
+        )}`,
       }),
     ])
   } else {
@@ -580,7 +582,7 @@ const validateFulltextArgumentInclude = (def, directive, argument) => {
         loc: directive.name.loc,
         entity: def.name.value,
         directive: fulltextDirectiveName(directive),
-        message: `@fulltext argument 'include' must have the form '[{entity: "entityName", fields: [{name: "fieldName"},... ]}... ]`,
+        message: `@fulltext argument 'include' must have the form '[{entity: "entityName", fields: [{name: "fieldName"}, ...]} ...]`,
       }),
     ])
   }

--- a/tests/cli/validation.test.js
+++ b/tests/cli/validation.test.js
@@ -172,4 +172,13 @@ describe('Validation', () => {
       exitCode: 1,
     },
   )
+
+  cliTest(
+    'Invalid @fullText directive',
+    ['codegen', '--skip-migrations'],
+    'validation/invalid-fulltext-directive',
+    {
+      exitCode: 1,
+    },
+  )
 })

--- a/tests/cli/validation.test.js
+++ b/tests/cli/validation.test.js
@@ -174,7 +174,7 @@ describe('Validation', () => {
   )
 
   cliTest(
-    'Invalid @fullText directive',
+    'Invalid @fulltext directive',
     ['codegen', '--skip-migrations'],
     'validation/invalid-fulltext-directive',
     {

--- a/tests/cli/validation/invalid-fulltext-directive.stderr
+++ b/tests/cli/validation/invalid-fulltext-directive.stderr
@@ -1,0 +1,5 @@
+- Load subgraph from subgraph.yaml
+✖ Failed to load subgraph from subgraph.yaml: Error in schema.graphql:
+
+  _Schema_:
+  - @fulltext include field 'name' must be a string

--- a/tests/cli/validation/invalid-fulltext-directive.stderr
+++ b/tests/cli/validation/invalid-fulltext-directive.stderr
@@ -1,5 +1,23 @@
 - Load subgraph from subgraph.yaml
 ✖ Failed to load subgraph from subgraph.yaml: Error in schema.graphql:
 
+  A:
+  - @fulltext directive only allowed on '_Schema_' type
+
   _Schema_:
-  - @fulltext include field 'name' must be a string
+  - @fulltext argument 'name' must be a string
+  - @fulltext 'language' value must be one of: simple, da, nl, en, fi, fr , de , hu , it , no , pt , ro , ru , es , sv , tr . For more details refer to the docs https://thegraph.com/docs/define-a-subgraph#defining-fulltext-search-fields.
+  - @fulltext 'algorithm' value, 'ranked', must be one of: rank, proximityRank
+  - @fulltext argument 'include > fields > name' must be the name of an entity field enclosed in double quotes
+  - @fulltext argument 'include > fields' must have the form '[{ name: "fieldName" }, ...]
+  - found invalid argument: 'style', @fulltext directives only allow 'name', 'language', 'algorithm', and 'includes' arguments
+  - @fulltext argument 'include' must be a list
+  - @fulltext argument 'name' must be specified
+  - @fulltext argument 'include' must be a list
+  - @fulltext argument 'language' must be specified
+  - @fulltext argument 'algorithm' must be specified
+  - @fulltext argument 'include' must be specified
+  - @fulltext argument 'include' must have the form '[{ entity: "entityName", fields: [{name: "fieldName"},...]}...]
+  - @fulltext argument include must have two fields, 'entity' and 'fields'}
+  - @fulltext argument 'include > other' must be be one of: [entity, fields]
+  - @fulltext include 'fields' must be a list

--- a/tests/cli/validation/invalid-fulltext-directive.stderr
+++ b/tests/cli/validation/invalid-fulltext-directive.stderr
@@ -1,42 +1,32 @@
 - Load subgraph from subgraph.yaml
 ✖ Failed to load subgraph from subgraph.yaml: Error in schema.graphql:
 
-    A:
-    - @fulltext directive only allowed on '_Schema_' type
+  A:
+  - @fulltext directive only allowed on '_Schema_' type
 
-    _Schema_:
-
-      badValuesProvided:
-      - @fulltext argument 'name' must be a string
-      - @fulltext directive 'language' value must be one of: simple, da, nl, en, fi, fr, de, hu, it, no, pt, ro, ru, es, sv, tr
-      - @fulltext 'algorithm' value, 'ranked', must be one of: rank, proximityRank
-
-      invalidField:
-      - @fulltext directive 'language' value must be one of: simple, da, nl, en, fi, fr, de, hu, it, no, pt, ro, ru, es, sv, tr
-      - @fulltext argument 'include > fields' must have the form '[{ name: "fieldName" }, ...]
-
-      invalidArgument:
-      - found invalid argument: 'style', @fulltext directives only allow 'name', 'language', 'algorithm', and 'includes' arguments
-
-      includeMustBeList:
-      - @fulltext argument 'include' must be a list
-
-      missingLanguageAlgorithmInclude:
-      - @fulltext argument 'language' must be specified
-      - @fulltext argument 'algorithm' must be specified
-      - @fulltext argument 'include' must be specified
-
-      includeItemNotObject:
-      - @fulltext argument 'include' must have the form '[{entity: "entityName", fields: [{name: "fieldName"},... ]}... ]
-
-      includeMissingEntityField:
-      - @fulltext argument include must have two fields, 'entity' and 'fields'
-
-      invalidIncludeArgumentOther:
-      - @fulltext argument 'include > other' must be be one of: entity, fields
-
-      includeFieldsMustBeList:
-      - @fulltext argument 'include > fields' must be a list
-
-      undefinedDirectiveName:
-      - @fulltext argument 'name' must be specified
+  _Schema_:
+    BadValuesProvided:
+    - @fulltext argument 'name' must be a string
+    - @fulltext directive 'language' value must be one of: simple, da, nl, en, fi, fr, de, hu, it, no, pt, ro, ru, es, sv, tr
+    - @fulltext 'algorithm' value, 'ranked', must be one of: rank, proximityRank
+    InvalidField:
+    - @fulltext directive 'language' value must be one of: simple, da, nl, en, fi, fr, de, hu, it, no, pt, ro, ru, es, sv, tr
+    - @fulltext argument 'include > fields' must have the form '[{ name: "fieldName" }, ...]
+    InvalidArgument:
+    - found invalid argument: 'style', @fulltext directives only allow 'name', 'language', 'algorithm', and 'includes' arguments
+    IncludeMustBeList:
+    - @fulltext argument 'include' must be a list
+    MissingLanguageAlgorithmInclude:
+    - @fulltext argument 'language' must be specified
+    - @fulltext argument 'algorithm' must be specified
+    - @fulltext argument 'include' must be specified
+    IncludeItemNotObject:
+    - @fulltext argument 'include' must have the form '[{entity: "entityName", fields: [{name: "fieldName"}, ...]} ...]
+    IncludeMissingEntityField:
+    - @fulltext argument include must have two fields, 'entity' and 'fields'
+    InvalidIncludeArgumentOther:
+    - @fulltext argument 'include > other' must be be one of: entity, fields
+    IncludeFieldsMustBeList:
+    - @fulltext argument 'include > fields' must be a list
+    Other:
+    - @fulltext argument 'name' must be specified

--- a/tests/cli/validation/invalid-fulltext-directive.stderr
+++ b/tests/cli/validation/invalid-fulltext-directive.stderr
@@ -1,23 +1,42 @@
 - Load subgraph from subgraph.yaml
 ✖ Failed to load subgraph from subgraph.yaml: Error in schema.graphql:
 
-  A:
-  - @fulltext directive only allowed on '_Schema_' type
+    A:
+    - @fulltext directive only allowed on '_Schema_' type
 
-  _Schema_:
-  - @fulltext argument 'name' must be a string
-  - @fulltext 'language' value must be one of: simple, da, nl, en, fi, fr , de , hu , it , no , pt , ro , ru , es , sv , tr . For more details refer to the docs https://thegraph.com/docs/define-a-subgraph#defining-fulltext-search-fields.
-  - @fulltext 'algorithm' value, 'ranked', must be one of: rank, proximityRank
-  - @fulltext argument 'include > fields > name' must be the name of an entity field enclosed in double quotes
-  - @fulltext argument 'include > fields' must have the form '[{ name: "fieldName" }, ...]
-  - found invalid argument: 'style', @fulltext directives only allow 'name', 'language', 'algorithm', and 'includes' arguments
-  - @fulltext argument 'include' must be a list
-  - @fulltext argument 'name' must be specified
-  - @fulltext argument 'include' must be a list
-  - @fulltext argument 'language' must be specified
-  - @fulltext argument 'algorithm' must be specified
-  - @fulltext argument 'include' must be specified
-  - @fulltext argument 'include' must have the form '[{ entity: "entityName", fields: [{name: "fieldName"},...]}...]
-  - @fulltext argument include must have two fields, 'entity' and 'fields'}
-  - @fulltext argument 'include > other' must be be one of: [entity, fields]
-  - @fulltext include 'fields' must be a list
+    _Schema_:
+
+      badValuesProvided:
+      - @fulltext argument 'name' must be a string
+      - @fulltext directive 'language' value must be one of: simple, da, nl, en, fi, fr, de, hu, it, no, pt, ro, ru, es, sv, tr
+      - @fulltext 'algorithm' value, 'ranked', must be one of: rank, proximityRank
+
+      invalidField:
+      - @fulltext directive 'language' value must be one of: simple, da, nl, en, fi, fr, de, hu, it, no, pt, ro, ru, es, sv, tr
+      - @fulltext argument 'include > fields' must have the form '[{ name: "fieldName" }, ...]
+
+      invalidArgument:
+      - found invalid argument: 'style', @fulltext directives only allow 'name', 'language', 'algorithm', and 'includes' arguments
+
+      includeMustBeList:
+      - @fulltext argument 'include' must be a list
+
+      missingLanguageAlgorithmInclude:
+      - @fulltext argument 'language' must be specified
+      - @fulltext argument 'algorithm' must be specified
+      - @fulltext argument 'include' must be specified
+
+      includeItemNotObject:
+      - @fulltext argument 'include' must have the form '[{entity: "entityName", fields: [{name: "fieldName"},... ]}... ]
+
+      includeMissingEntityField:
+      - @fulltext argument include must have two fields, 'entity' and 'fields'
+
+      invalidIncludeArgumentOther:
+      - @fulltext argument 'include > other' must be be one of: entity, fields
+
+      includeFieldsMustBeList:
+      - @fulltext argument 'include > fields' must be a list
+
+      undefinedDirectiveName:
+      - @fulltext argument 'name' must be specified

--- a/tests/cli/validation/invalid-fulltext-directive/Abi.json
+++ b/tests/cli/validation/invalid-fulltext-directive/Abi.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "event",
+    "name": "ExampleEvent",
+    "inputs": [{ "type": "string" }]
+  }
+]

--- a/tests/cli/validation/invalid-fulltext-directive/schema.graphql
+++ b/tests/cli/validation/invalid-fulltext-directive/schema.graphql
@@ -1,0 +1,20 @@
+type _Schema_
+  @fullText(
+    name: "jf"
+    language: "english"
+    algorithm: ranked
+    include: [
+      {
+        entity: "Musician",
+        fields: [
+          { name: 9, weight: 10 },
+          { name: "bio", weight: 5 },
+        ]
+      }
+    ]
+)
+
+type B @entity {
+  id: ID!
+  foo: String!
+}

--- a/tests/cli/validation/invalid-fulltext-directive/schema.graphql
+++ b/tests/cli/validation/invalid-fulltext-directive/schema.graphql
@@ -1,5 +1,5 @@
 type _Schema_
-  @fullText(
+  @fulltext(
     name: "jf"
     language: "english"
     algorithm: ranked

--- a/tests/cli/validation/invalid-fulltext-directive/schema.graphql
+++ b/tests/cli/validation/invalid-fulltext-directive/schema.graphql
@@ -1,7 +1,7 @@
 type _Schema_
   @fulltext(
     name: "jf"
-    language: ENGLISH
+    language: EN
     algorithm: RANKED
     include: [
       {

--- a/tests/cli/validation/invalid-fulltext-directive/schema.graphql
+++ b/tests/cli/validation/invalid-fulltext-directive/schema.graphql
@@ -2,7 +2,7 @@ type _Schema_
   @fulltext(
     name: "jf"
     language: "english"
-    algorithm: ranked
+    algorithm: RANKED
     include: [
       {
         entity: "Musician",

--- a/tests/cli/validation/invalid-fulltext-directive/schema.graphql
+++ b/tests/cli/validation/invalid-fulltext-directive/schema.graphql
@@ -1,14 +1,14 @@
 type _Schema_
   @fulltext(
     name: "jf"
-    language: "english"
+    language: ENGLISH
     algorithm: RANKED
     include: [
       {
         entity: "Musician",
         fields: [
-          { name: 9, weight: 10 },
-          { name: "bio", weight: 5 },
+          { name: 9, weight: A },
+          { name: "bio", weight: B },
         ]
       }
     ]

--- a/tests/cli/validation/invalid-fulltext-directive/schema.graphql
+++ b/tests/cli/validation/invalid-fulltext-directive/schema.graphql
@@ -1,25 +1,128 @@
 type _Schema_
   @fulltext(
-    name: "jf"
-    language: EN
-    algorithm: RANKED
+    name: bad_values_provided
+    language: english
+    algorithm: ranked
     include: [
       {
         entity: "Musician",
         fields: [
           { name: 9 },
           { name: "bio" },
+          "friend"
         ]
       }
     ]
 )
+@fulltext(
+  name: "invalid_argument"
+  language: en
+  algorithm: rank
+  style: best
+  include: [
+    {
+      entity: "Musician",
+      fields: [
+        { name: "ok" },
+        { name: "bio" },
+      ]
+    }
+  ]
+)
+@fulltext(
+  name: "include_not_a_list"
+  language: en
+  algorithm: rank
+  include:
+    {
+      entity: "Musician",
+      fields: [
+        { name: "ok" },
+        { name: "bio" },
+      ]
+    }
+)
+@fulltext(
+  language: en
+  algorithm: rank
+  include:
+  {
+    entity: "Musician",
+    fields: [
+      { name: "ok" },
+      { name: "bio" },
+    ]
+  }
+)
+@fulltext(
+  name: "missing_language_and_algorithm_and_include"
+)
+@fulltext(
+  name: "include_item_not_an_object"
+  language: en
+  algorithm: rank
+  include: [
+    "Musician",
+  ]
+)
+@fulltext(
+  name: "include_missing_entity_field"
+  language: en
+  algorithm: rank
+  include: [
+    {
+      fields: [
+        { name: "ok" },
+        { name: "bio" },
+      ]
+    }
+  ]
+)
+@fulltext(
+  name: "invalid_include_argument_other"
+  language: en
+  algorithm: rank
+  include: [
+    {
+      other: "wrong"
+      fields: [
+        { name: "ok" },
+        { name: "bio" },
+      ],
+    }
+  ]
+)
+@fulltext(
+  name: "include_fields_must_be_a_list"
+  language: en
+  algorithm: rank
+  include: [
+    {
+      entity: "Musician",
+      fields: "instrument",
+    }
+  ]
+)
 
-enum __FulltextAlgorithm {
-  RANKED
-  PROXIMITY_RANKED
+type A @entity @fulltext(
+  name: "fulltext_on_wrong_type"
+  language: en
+  algorithm: rank
+  include: [
+    {
+      entity: "Musician",
+      fields: [
+        { name: "9" },
+        { name: "bio" },
+      ]
+    }
+  ]
+) {
+  id: ID!
 }
 
 type B @entity {
   id: ID!
   foo: String!
 }
+

--- a/tests/cli/validation/invalid-fulltext-directive/schema.graphql
+++ b/tests/cli/validation/invalid-fulltext-directive/schema.graphql
@@ -7,12 +7,17 @@ type _Schema_
       {
         entity: "Musician",
         fields: [
-          { name: 9, weight: A },
-          { name: "bio", weight: B },
+          { name: 9 },
+          { name: "bio" },
         ]
       }
     ]
 )
+
+enum __FulltextAlgorithm {
+  RANKED
+  PROXIMITY_RANKED
+}
 
 type B @entity {
   id: ID!

--- a/tests/cli/validation/invalid-fulltext-directive/schema.graphql
+++ b/tests/cli/validation/invalid-fulltext-directive/schema.graphql
@@ -1,6 +1,6 @@
 type _Schema_
 @fulltext(
-  name: badValuesProvided
+  name: BadValuesProvided
   language: english
   algorithm: ranked
   include: [
@@ -14,7 +14,7 @@ type _Schema_
   ]
 )
 @fulltext(
-  name: "invalidField"
+  name: "InvalidField"
   language: english
   algorithm: rank
   include: [
@@ -28,7 +28,7 @@ type _Schema_
   ]
 )
 @fulltext(
-  name: "invalidArgument"
+  name: "InvalidArgument"
   language: en
   algorithm: rank
   style: best
@@ -43,7 +43,7 @@ type _Schema_
   ]
 )
 @fulltext(
-  name: "includeMustBeList"
+  name: "IncludeMustBeList"
   language: en
   algorithm: rank
   include:
@@ -56,10 +56,10 @@ type _Schema_
   }
 )
 @fulltext(
-  name: "missingLanguageAlgorithmInclude"
+  name: "MissingLanguageAlgorithmInclude"
 )
 @fulltext(
-  name: "includeItemNotObject"
+  name: "IncludeItemNotObject"
   language: en
   algorithm: rank
   include: [
@@ -67,7 +67,7 @@ type _Schema_
   ]
 )
 @fulltext(
-  name: "includeMissingEntityField"
+  name: "IncludeMissingEntityField"
   language: en
   algorithm: rank
   include: [
@@ -80,7 +80,7 @@ type _Schema_
   ]
 )
 @fulltext(
-  name: "invalidIncludeArgumentOther"
+  name: "InvalidIncludeArgumentOther"
   language: en
   algorithm: rank
   include: [
@@ -94,7 +94,7 @@ type _Schema_
   ]
 )
 @fulltext(
-  name: "includeFieldsMustBeList"
+  name: "IncludeFieldsMustBeList"
   language: en
   algorithm: rank
   include: [
@@ -118,7 +118,7 @@ type _Schema_
   ]
 )
 type A @entity @fulltext(
-  name: "fulltextOnWrongType"
+  name: "FulltextOnWrongType"
   language: en
   algorithm: rank
   include: [

--- a/tests/cli/validation/invalid-fulltext-directive/schema.graphql
+++ b/tests/cli/validation/invalid-fulltext-directive/schema.graphql
@@ -1,21 +1,34 @@
 type _Schema_
-  @fulltext(
-    name: bad_values_provided
-    language: english
-    algorithm: ranked
-    include: [
-      {
-        entity: "Musician",
-        fields: [
-          { name: 9 },
-          { name: "bio" },
-          "friend"
-        ]
-      }
-    ]
+@fulltext(
+  name: badValuesProvided
+  language: english
+  algorithm: ranked
+  include: [
+    {
+      entity: "Musician",
+      fields: [
+        { name: "9" },
+        { name: "bio" },
+      ]
+    }
+  ]
 )
 @fulltext(
-  name: "invalid_argument"
+  name: "invalidField"
+  language: english
+  algorithm: rank
+  include: [
+    {
+      entity: "Musician",
+      fields: [
+        { name:  "9" },
+        "bio"
+      ]
+    }
+  ]
+)
+@fulltext(
+  name: "invalidArgument"
   language: en
   algorithm: rank
   style: best
@@ -30,19 +43,7 @@ type _Schema_
   ]
 )
 @fulltext(
-  name: "include_not_a_list"
-  language: en
-  algorithm: rank
-  include:
-    {
-      entity: "Musician",
-      fields: [
-        { name: "ok" },
-        { name: "bio" },
-      ]
-    }
-)
-@fulltext(
+  name: "includeMustBeList"
   language: en
   algorithm: rank
   include:
@@ -55,10 +56,10 @@ type _Schema_
   }
 )
 @fulltext(
-  name: "missing_language_and_algorithm_and_include"
+  name: "missingLanguageAlgorithmInclude"
 )
 @fulltext(
-  name: "include_item_not_an_object"
+  name: "includeItemNotObject"
   language: en
   algorithm: rank
   include: [
@@ -66,7 +67,7 @@ type _Schema_
   ]
 )
 @fulltext(
-  name: "include_missing_entity_field"
+  name: "includeMissingEntityField"
   language: en
   algorithm: rank
   include: [
@@ -79,7 +80,7 @@ type _Schema_
   ]
 )
 @fulltext(
-  name: "invalid_include_argument_other"
+  name: "invalidIncludeArgumentOther"
   language: en
   algorithm: rank
   include: [
@@ -93,7 +94,7 @@ type _Schema_
   ]
 )
 @fulltext(
-  name: "include_fields_must_be_a_list"
+  name: "includeFieldsMustBeList"
   language: en
   algorithm: rank
   include: [
@@ -103,9 +104,21 @@ type _Schema_
     }
   ]
 )
-
+@fulltext(
+  language: en
+  algorithm: rank
+  include: [
+    {
+      entity: "Musician",
+      fields: [
+        { name: "ok" },
+        { name: "bio" },
+      ]
+    }
+  ]
+)
 type A @entity @fulltext(
-  name: "fulltext_on_wrong_type"
+  name: "fulltextOnWrongType"
   language: en
   algorithm: rank
   include: [
@@ -125,4 +138,3 @@ type B @entity {
   id: ID!
   foo: String!
 }
-

--- a/tests/cli/validation/invalid-fulltext-directive/subgraph.yaml
+++ b/tests/cli/validation/invalid-fulltext-directive/subgraph.yaml
@@ -1,0 +1,40 @@
+specVersion: 0.0.1
+schema:
+  file: ./schema.graphql
+dataSources:
+  - kind: ethereum/contract
+    name: ExampleSubgraph
+    source:
+      address: '22843e74c59580b3eaf6c233fa67d8b7c561a835'
+      abi: ExampleContract
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.1
+      language: wasm/assemblyscript
+      file: ./mapping.ts
+      entities:
+        - ExampleEntity
+      abis:
+        - name: ExampleContract
+          file: ./Abi.json
+      eventHandlers:
+        - event: ExampleEvent(string)
+          handler: handleExampleEvent
+templates:
+  - kind: ethereum/contract
+    name: ExampleTemplate
+    source:
+      abi: ExampleContract
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.1
+      language: wasm/assemblyscript
+      file: ./mapping.ts
+      entities:
+        - ExampleEntity
+      abis:
+        - name: ExampleContract
+          file: ./Abi.json
+      eventHandlers:
+        - event: ExampleEvent(string)
+          handler: handleExampleEvent

--- a/tests/cli/validation/invalid-fulltext-directive/subgraph.yaml
+++ b/tests/cli/validation/invalid-fulltext-directive/subgraph.yaml
@@ -20,21 +20,3 @@ dataSources:
       eventHandlers:
         - event: ExampleEvent(string)
           handler: handleExampleEvent
-templates:
-  - kind: ethereum/contract
-    name: ExampleTemplate
-    source:
-      abi: ExampleContract
-    mapping:
-      kind: ethereum/events
-      apiVersion: 0.0.1
-      language: wasm/assemblyscript
-      file: ./mapping.ts
-      entities:
-        - ExampleEntity
-      abis:
-        - name: ExampleContract
-          file: ./Abi.json
-      eventHandlers:
-        - event: ExampleEvent(string)
-          handler: handleExampleEvent


### PR DESCRIPTION
Validate the structure and types specified as @fulltext directive arguments. 

Fulltext directives are added to the custom _Schema_ type (also used for @import directives). 

```graphql
type _Schema_ 
  @fulltext(
    name: "media"
    ...
  )
  @fulltext(
    name: "search",
    language: en,
    algorithm: rank,
    include: [
      {
        entity: "Band",
        fields: [
          { name: "name" },
        ]
      },
      {
        entity: "Album",
        fields: [
          { name: "title" },
        ]
      },
      {
        entity: "Musician",
        fields: [
          { name: "name" },
          { name: "bio" },
        ]
      }
    ]
  )
```