### PR TITLE
Fix ABI generator param types for tuple arrays

### DIFF
--- a/src/codegen/util.js
+++ b/src/codegen/util.js
@@ -13,8 +13,12 @@ const disambiguateNames = ({ values, getName, setName }) => {
   })
 }
 
+const isTupleType = t => {
+  return t === 'tuple'
+}
+
 const containsTupleType = t => {
-  return t === 'tuple' || t.match(/^tuple\[([0-9]+)?\]$/)
+  return isTupleType(t) || isTupleArrayType(t)
 }
 
 const isTupleArrayType = t => {
@@ -38,6 +42,7 @@ const unrollTuple = ({ path, index, value }) =>
 module.exports = {
   containsTupleType,
   disambiguateNames,
+  isTupleType,
   isTupleArrayType,
   unrollTuple,
 }


### PR DESCRIPTION
Locally, this seems to fix the problem described in #455. I also added an `isTupleType` util to match `isTupleArrayType`.

Before:

```typescript
export class BasketManager__getBasketResultBStruct extends ethereum.Tuple {
  get bassets(): Array<ethereum.Tuple> {
    return this[0].toTupleArray<undefined>();
```

After:

```typescript
export class BasketManager__getBasketResultBStruct extends ethereum.Tuple {
  get bassets(): Array<BasketManager__getBasketResultBBassetsStruct> {
    return this[0].toTupleArray<BasketManager__getBasketResultBBassetsStruct>(); // This struct was generated, too
```

Before:

```typescript
export class BasketManager__getBassetsResult {
  value0: Array<ethereum.Tuple>;
```

After:

```typescript
export class BasketManager__getBassetsResult {
  value0: Array<BasketManager__getBassetsResultBAssetsStruct>;
```

Resolves #455 