### PR TITLE
Added support of contract name in graph init command

### DIFF
--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -33,11 +33,12 @@ ${chalk.dim('Options for --from-contract:')}
       --network <mainnet|kovan|rinkeby|ropsten|goerli|poa-core>
                                 Selects the network the contract is deployed to
       --index-events            Index contract events as entities
+      --contract-name           Name of the contract (default: Contract)      
 `
 
 const processInitForm = async (
   toolbox,
-  { abi, address, allowSimpleName, directory, fromExample, network, subgraphName },
+  {abi, address, allowSimpleName, directory, fromExample, network, subgraphName, contractName},
 ) => {
   let networkChoices = ['mainnet', 'kovan', 'rinkeby', 'ropsten', 'goerli', 'poa-core']
   let addressPattern = /^(0x)?[0-9a-fA-F]{40}$/
@@ -147,6 +148,18 @@ const processInitForm = async (
         }
       },
     },
+    {
+      type: 'input',
+      name: 'contractName',
+      message: 'Contract Name',
+      initial: contractName || 'Contract',
+      skip: () => fromExample !== undefined,
+      validate: value => value && value.length > 0,
+      result: value => {
+        contractName = value;
+        return value;
+      }
+    },
   ]
 
   try {
@@ -233,6 +246,7 @@ module.exports = {
       abi,
       allowSimpleName,
       fromContract,
+      contractName,
       fromExample,
       h,
       help,
@@ -338,6 +352,7 @@ module.exports = {
           indexEvents,
           network,
           subgraphName,
+          contractName,
         },
         { commands },
       )
@@ -352,6 +367,7 @@ module.exports = {
       fromExample,
       network,
       subgraphName,
+      contractName
     })
 
     // Exit immediately when the form is cancelled
@@ -382,6 +398,7 @@ module.exports = {
           network: inputs.network,
           address: inputs.address,
           indexEvents,
+          contractName: inputs.contractName
         },
         { commands },
       )
@@ -571,7 +588,7 @@ const initSubgraphFromExample = async (
 
 const initSubgraphFromContract = async (
   toolbox,
-  { allowSimpleName, subgraphName, directory, abi, network, address, indexEvents },
+  {allowSimpleName, subgraphName, directory, abi, network, address, indexEvents, contractName},
   { commands },
 ) => {
   let { print } = toolbox
@@ -609,6 +626,7 @@ const initSubgraphFromContract = async (
           network,
           address,
           indexEvents,
+          contractName,
         },
         spinner,
       )

--- a/src/scaffold.test.js
+++ b/src/scaffold.test.js
@@ -80,6 +80,7 @@ describe('Subgraph scaffolding', () => {
         abi: TEST_ABI,
         network: 'kovan',
         address: '0xf87e31492faf9a91b02ee0deaad50d51d56d5d4d',
+        contractName: 'Contract'
       }),
     ).toEqual(`\
 specVersion: 0.0.1
@@ -146,7 +147,7 @@ type ExampleEvent1 @entity {
   })
 
   test('Mapping (default)', () => {
-    expect(generateMapping({ abi: TEST_ABI })).toEqual(`\
+    expect(generateMapping({ abi: TEST_ABI, contractName: 'Contract' })).toEqual(`\
 import { BigInt } from "@graphprotocol/graph-ts"
 import {
   Contract,
@@ -203,7 +204,7 @@ export function handleExampleEvent1(event: ExampleEvent1): void {}
   })
 
   test('Mapping (for indexing events)', () => {
-    expect(generateMapping({ abi: TEST_ABI, indexEvents: true })).toEqual(`\
+    expect(generateMapping({ abi: TEST_ABI, indexEvents: true, contractName: 'Contract' })).toEqual(`\
 import {
   ExampleEvent as ExampleEventEvent,
   ExampleEvent1 as ExampleEvent1Event


### PR DESCRIPTION
Currently if `graph init` is used to create project, all the files are name as `Contract`. This PR adds a optional parameter `--contract-name` in the `graph init` command. This name will be used to create subgraph project files. 

Why this is needed? 
While creating subgraph project with many contract, we use `graph init` command for each contract and merge those projects. One step while merging the projects is renaming files by contract name to make it more readable. This option will ease the process and make it less erroneous. 

Next step after this PR approach looks fine: Create separate PR to accept multiple contract addresses and name in `graph init`