### PR TITLE
Manifest schema: allow specifying a graft base

### DIFF
--- a/manifest-schema.graphql
+++ b/manifest-schema.graphql
@@ -60,11 +60,17 @@ type EthereumContractEventHandler {
   handler: String!
 }
 
+type Graft {
+  base: String!
+  block: BigInt!
+}
+
 type SubgraphManifest {
   specVersion: String!
   schema: Schema!
   description: String
   repository: String
+  graft: Graft
   dataSources: [DataSource!]!
   templates: [DataSourceTemplate!]
 }


### PR DESCRIPTION
This is needed to enable using the functionality in https://github.com/graphprotocol/graph-node/pull/1572