### PR TITLE
Fixing path lookups in compiler script.

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -181,16 +181,6 @@ class Compiler {
     }
   }
 
-  _copySubgraphFile(maybeRelativeFile, sourceDir, targetDir, spinner) {
-    let absoluteSourceFile = path.resolve(sourceDir, maybeRelativeFile)
-    let relativeSourceFile = path.relative(sourceDir, absoluteSourceFile)
-    let targetFile = path.resolve(targetDir, relativeSourceFile)
-    step(spinner, 'Copy subgraph file', this.displayPath(targetFile))
-    fs.mkdirsSync(path.dirname(targetFile))
-    fs.copyFileSync(absoluteSourceFile, targetFile)
-    return targetFile
-  }
-
   _writeSubgraphFile(maybeRelativeFile, data, sourceDir, targetDir, spinner) {
     let absoluteSourceFile = path.resolve(sourceDir, maybeRelativeFile)
     let relativeSourceFile = path.relative(sourceDir, absoluteSourceFile)


### PR DESCRIPTION
Currently, the path values passed to `asc.main` are not correctly resolving the libs directory relative to the current working directory in all cases. Also, the build directory path is not getting resolved relative to the `cwd` when adding the --output-dir option to the `build` or `deploy` commands.