### PR TITLE
Asc debug flag

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -291,6 +291,7 @@ class Compiler {
           '--outFile',
           outputFile,
           '--optimize',
+          '--debug',
         ],
         {
           stdout: process.stdout,
@@ -372,6 +373,7 @@ class Compiler {
           '--outFile',
           outputFile,
           '--optimize',
+          '--debug',
         ],
         {
           stdout: process.stdout,


### PR DESCRIPTION
Now that wasmtime gives us stack traces, we need this so that they have useful function names.