### PR TITLE
Add support for CLI plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dockerode": "^2.5.8",
     "fs-extra": "^9.0.0",
     "glob": "^7.1.2",
-    "gluegun": "^4.1.2",
+    "gluegun": "^4.3.1",
     "graphql": "^14.0.2",
     "immutable": "^3.8.2",
     "ipfs-http-client": "^34.0.0",

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,10 +1,34 @@
-const { build } = require('gluegun')
+const path = require('path')
+const { exec } = require('child_process')
+const which = require('which')
+const { build, system } = require('gluegun')
 
 const run = async argv => {
-  const cli = build()
+  let cli = build()
     .brand('graph')
     .src(__dirname)
-    .plugins('./node_modules', { matching: 'graph-cli-*', hidden: true })
+
+  const pluginDirs = []
+  try {
+    const npmGlobalRoot = await system.run('npm root -g', { trim: true })
+    pluginDirs.push(npmGlobalRoot)
+  } catch (_) {}
+  try {
+    const npmUserRoot = await system.run('npm root', { trim: true })
+    pluginDirs.push(npmUserRoot)
+  } catch (_) {}
+  try {
+    const yarnUserRoot = await system.run('yarn global dir', { trim: true })
+    pluginDirs.push(yarnUserRoot)
+  } catch (_) {}
+
+  // Inject potential plugin directories
+  cli = pluginDirs.reduce(
+    (cli, dir) => cli.plugin(path.join(dir, '@graphprotocol', 'indexer-cli', 'dist')),
+    cli,
+  )
+
+  cli = cli
     .help()
     .version()
     .defaultCommand()

--- a/src/cli.js
+++ b/src/cli.js
@@ -8,19 +8,17 @@ const run = async argv => {
     .brand('graph')
     .src(__dirname)
 
-  const pluginDirs = []
-  try {
-    const npmGlobalRoot = await system.run('npm root -g', { trim: true })
-    pluginDirs.push(npmGlobalRoot)
-  } catch (_) {}
-  try {
-    const npmUserRoot = await system.run('npm root', { trim: true })
-    pluginDirs.push(npmUserRoot)
-  } catch (_) {}
-  try {
-    const yarnUserRoot = await system.run('yarn global dir', { trim: true })
-    pluginDirs.push(yarnUserRoot)
-  } catch (_) {}
+  const pluginDirs = (
+    await Promise.all(
+      ['npm root -g', 'npm root', 'yarn global dir'].map(async cmd => {
+        try {
+          return await system.run(cmd, { trim: true })
+        } catch (_) {
+          return undefined
+        }
+      }),
+    )
+  ).filter(dir => dir !== undefined)
 
   // Inject potential plugin directories
   cli = pluginDirs.reduce(

--- a/yarn.lock
+++ b/yarn.lock
@@ -2368,10 +2368,10 @@ globals@^12.1.0:
   dependencies:
     type-fest "^0.8.1"
 
-gluegun@^4.1.2:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/gluegun/-/gluegun-4.3.0.tgz#1e873605cf51a8954c10b4005af3854df556712a"
-  integrity sha512-NxjvfuBwVkC2o9cuUUJerLJFIDUs7IfxJagc5prLrLbmPUI/Xek3mA9OQK6FL5nlUwVGT7BYlw7og0mehAyfGQ==
+gluegun@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.npmjs.org/gluegun/-/gluegun-4.3.1.tgz#b93a8619e2e9546ab3451ad94f7be9097c75083a"
+  integrity sha512-TyOf60807SUYvd0v7fiRbhWrBSl9974clwZwCVc3qxYB83TQQQUSggwcz3yUeOl1MBALpwrz0Q0GUmi25quVOg==
   dependencies:
     apisauce "^1.0.1"
     app-module-path "^2.2.0"


### PR DESCRIPTION
This sets Graph CLI up to detect plugin packages that extend the set of commands provided by `graph`.