### PR TITLE
Emit a warning when multiple data sources have duplicate functionality

### DIFF
--- a/tests/cli/validation.test.js
+++ b/tests/cli/validation.test.js
@@ -163,6 +163,15 @@ describe('Validation', () => {
   )
 
   cliTest(
+    'Duplicate data source functionality',
+    ['codegen', '--skip-migrations'],
+    'validation/duplicate-data-source-functionality',
+    {
+      exitCode: 0,
+    },
+  )
+
+  cliTest(
     'Duplicate template name',
     ['codegen', '--skip-migrations'],
     'validation/duplicate-template-name',

--- a/tests/cli/validation/duplicate-data-source-functionality.stderr
+++ b/tests/cli/validation/duplicate-data-source-functionality.stderr
@@ -1,0 +1,36 @@
+- Load subgraph from subgraph.yaml
+⚠ Warnings while loading subgraph from subgraph.yaml: Warnings in subgraph.yaml:
+
+    Path: dataSources > 1
+    This data source, 'ExampleSubgraph1', has identical source and mapping to an already declared data source.
+    They will both listen to the same triggers, process them with the same mappings, and generate the same entity updates.
+
+✔ Load subgraph from subgraph.yaml
+- Load contract ABIs
+  Load contract ABI from Abi.json
+- Load contract ABIs
+  Load contract ABI from Abi.json
+- Load contract ABIs
+✔ Load contract ABIs
+- Generate types for contract ABIs
+  Generate types for contract ABI: ExampleContract (Abi.json)
+- Generate types for contract ABIs
+  Write types to generated/ExampleSubgraph/ExampleContract.ts
+- Generate types for contract ABIs
+  Generate types for contract ABI: ExampleContract (Abi.json)
+- Generate types for contract ABIs
+  Write types to generated/ExampleSubgraph1/ExampleContract.ts
+- Generate types for contract ABIs
+✔ Generate types for contract ABIs
+- Generate types for data source templates
+✔ Generate types for data source templates
+- Load data source template ABIs
+✔ Load data source template ABIs
+- Generate types for data source template ABIs
+✔ Generate types for data source template ABIs
+- Load GraphQL schema from schema.graphql
+✔ Load GraphQL schema from schema.graphql
+- Generate types for GraphQL schema
+  Write types to generated/schema.ts
+- Generate types for GraphQL schema
+✔ Generate types for GraphQL schema

--- a/tests/cli/validation/duplicate-data-source-functionality/Abi.json
+++ b/tests/cli/validation/duplicate-data-source-functionality/Abi.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "event",
+    "name": "ExampleEvent",
+    "inputs": [{ "type": "string" }]
+  }
+]

--- a/tests/cli/validation/duplicate-data-source-functionality/schema.graphql
+++ b/tests/cli/validation/duplicate-data-source-functionality/schema.graphql
@@ -1,0 +1,4 @@
+type MyEntity @entity {
+  id: ID!
+  x: BigDecimal!
+}

--- a/tests/cli/validation/duplicate-data-source-functionality/subgraph.yaml
+++ b/tests/cli/validation/duplicate-data-source-functionality/subgraph.yaml
@@ -1,0 +1,40 @@
+specVersion: 0.0.1
+repository: https://github.com/graphprotocol/test-subgraph
+description: Test subgraph
+schema:
+  file: ./schema.graphql
+dataSources:
+  - kind: ethereum/contract
+    name: ExampleSubgraph
+    source:
+      abi: ExampleContract
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.1
+      language: wasm/assemblyscript
+      file: ./mapping.ts
+      entities:
+        - ExampleEntity
+      abis:
+        - name: ExampleContract
+          file: ./Abi.json
+      eventHandlers:
+        - event: ExampleEvent(string)
+          handler: handleExampleEvent
+  - kind: ethereum/contract
+    name: ExampleSubgraph1
+    source:
+      abi: ExampleContract
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.1
+      language: wasm/assemblyscript
+      file: ./mapping.ts
+      entities:
+        - ExampleEntity
+      abis:
+        - name: ExampleContract
+          file: ./Abi.json
+      eventHandlers:
+        - event: ExampleEvent(string)
+          handler: handleExampleEvent


### PR DESCRIPTION
Includes an additional check during subgraph validation to identify data sources which are functionally equivalent. 
If a subgraph is deployed with functionally equivalent data sources it will likely lead to unexpected entity data such as double counting. 