### PR TITLE
tuple[][] types

### DIFF
--- a/src/codegen/types/conversions.js
+++ b/src/codegen/types/conversions.js
@@ -48,7 +48,7 @@ const ETHEREUM_VALUE_TO_ASSEMBLYSCRIPT = [
 
   ['tuple', 'ethereum.Tuple', code => `${code}.toTuple()`],
   [
-    /^tuple\[([0-9]+)?\]$/,
+    /^tuple(\[([0-9]+)?\])+$/,
     'Array<ethereum.Tuple>',
     (code, type) => `${code}.toTupleArray<${type}>()`,
   ],

--- a/src/codegen/util.js
+++ b/src/codegen/util.js
@@ -22,7 +22,7 @@ const containsTupleType = t => {
 }
 
 const isTupleArrayType = t => {
-  return t.match(/^tuple\[([0-9]+)?\]$/)
+  return t.match(/^tuple(\[([0-9]+)?\])+$/)
 }
 
 const unrollTuple = ({ path, index, value }) =>


### PR DESCRIPTION
Working on #588

With a regex change, codegen succeeds for  `tuple[][]` types. but I cant say anything for the actual code it generated. Naively deploying it I get

```
Subgraph instance failed to run: Failed to process trigger: Unknown function "Contract::bulkGetPlanetArrivals" with signature `bulkGetPlanetArrivals(uint256,uint256):(tuple[][])` called from WASM runtime wasm backtrace: 0: 0x11ef - <unknown>!<wasm function 43> 1: 0x1b2f - <unknown>!<wasm function 73> 2: 0x1b79 - <unknown>!<wasm function 75> , code: SubgraphSyncingFailure, id: QmTcm4ZAB3U7g7oXgAxUEz6yjwqx4DUScbno5xNPg5b8h1
```
Generated code is
```
export class Contract__bulkGetPlanetArrivalsResultValue0Struct extends ethereum.Tuple {
  get id(): BigInt {
    return this[0].toBigInt();
  }

  get player(): Address {
    return this[1].toAddress();
  }

  get fromPlanet(): BigInt {
    return this[2].toBigInt();
  }

  get toPlanet(): BigInt {
    return this[3].toBigInt();
  }

  get popArriving(): BigInt {
    return this[4].toBigInt();
  }

  get silverMoved(): BigInt {
    return this[5].toBigInt();
  }

  get departureTime(): BigInt {
    return this[6].toBigInt();
  }

  get arrivalTime(): BigInt {
    return this[7].toBigInt();
  }
}
...
export class Contract extends ethereum.SmartContract {
....
  bulkGetPlanetArrivals(
    startIdx: BigInt,
    endIdx: BigInt
  ): Array<Contract__bulkGetPlanetArrivalsResultValue0Struct> {
    let result = super.call(
      "bulkGetPlanetArrivals",
      "bulkGetPlanetArrivals(uint256,uint256):(tuple[][])",
      [
        ethereum.Value.fromUnsignedBigInt(startIdx),
        ethereum.Value.fromUnsignedBigInt(endIdx)
      ]
    );

    return result[0].toTupleArray<
      Contract__bulkGetPlanetArrivalsResultValue0Struct
    >();
  }

  try_bulkGetPlanetArrivals(
    startIdx: BigInt,
    endIdx: BigInt
  ): ethereum.CallResult<
    Array<Contract__bulkGetPlanetArrivalsResultValue0Struct>
  > {
    let result = super.tryCall(
      "bulkGetPlanetArrivals",
      "bulkGetPlanetArrivals(uint256,uint256):(tuple[][])",
      [
        ethereum.Value.fromUnsignedBigInt(startIdx),
        ethereum.Value.fromUnsignedBigInt(endIdx)
      ]
    );
    if (result.reverted) {
      return new ethereum.CallResult();
    }
    let value = result.value;
    return ethereum.CallResult.fromValue(
      value[0].toTupleArray<Contract__bulkGetPlanetArrivalsResultValue0Struct>()
    );
  }
```
Im not too sure what multidimensional access should look like, anyone have an example?