### PR TITLE
fix print bug when there is an error in setting up the 'graph test' e…

### DIFF
--- a/src/commands/test.js
+++ b/src/commands/test.js
@@ -113,7 +113,7 @@ module.exports = {
     try {
       await startTestEnvironment(tempdir)
     } catch (e) {
-      print.error(`${e}`)
+      print.error(e)
       process.exitCode = 1
       return
     }


### PR DESCRIPTION
…nvironment.

Prior to this commit, if an error occured when setting up the 'graph test' command's test environment, the error would be printed as '[Object object]', because Javascript's String interpolation does not handle Javascript Objects well. Now it prints out the full error message, allowing developers to quickly debug why 'graph test' is not working.