### PR TITLE
Added basic url auth support

### DIFF
--- a/src/command-helpers/jsonrpc.js
+++ b/src/command-helpers/jsonrpc.js
@@ -3,6 +3,7 @@ const toolbox = require('gluegun/toolbox')
 
 const createJsonRpcClient = url => {
   let params = {
+    auth: url.auth,
     host: url.hostname,
     port: url.port,
     path: url.pathname,


### PR DESCRIPTION
Not sure why this wasn't included, but allowing the usage of the auth parameter of the URL will allow for basic authentication (user and password) if you don't want to run a JWT authentication solution, but still want some simple form of authentication when deploying.

Was there a security reason why this wasn't included?