### PR TITLE
Init command updated to support all hosted-service compatible networks

### DIFF
--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -30,7 +30,7 @@ ${chalk.dim('Choose mode with one of:')}
 ${chalk.dim('Options for --from-contract:')}
 
       --abi <path>              Path to the contract ABI (default: download from Etherscan)
-      --network <mainnet|kovan|rinkeby|ropsten|goerli|poa-core>
+      --network <mainnet|kovan|rinkeby|ropsten|goerli|poa-core|poa-sokol|xdai|matic|mumbai|fantom|bsc|clover>
                                 Selects the network the contract is deployed to
       --index-events            Index contract events as entities
       --contract-name           Name of the contract (default: Contract)      
@@ -40,7 +40,21 @@ const processInitForm = async (
   toolbox,
   {abi, address, allowSimpleName, directory, fromExample, network, subgraphName, contractName},
 ) => {
-  let networkChoices = ['mainnet', 'kovan', 'rinkeby', 'ropsten', 'goerli', 'poa-core']
+  let networkChoices = [
+    'mainnet',
+    'kovan',
+    'rinkeby',
+    'ropsten',
+    'goerli',
+    'poa-core',
+    'poa-sokol',
+    'xdai',
+    'matic',
+    'mumbai',
+    'fantom',
+    'bsc',
+    'clover',
+  ]
   let addressPattern = /^(0x)?[0-9a-fA-F]{40}$/
 
   let abiFromEtherscan = undefined


### PR DESCRIPTION
Add `graph init ...` support for `poa-sokol`, `xdai`, `matic`, mumbai, `fantom`, `bsc`, and `clover`.