### PR TITLE
add support to load generated manifests

### DIFF
--- a/src/migrations/mapping_api_version_0_0_1.js
+++ b/src/migrations/mapping_api_version_0_0_1.js
@@ -3,6 +3,7 @@ const semver = require('semver')
 const toolbox = require('gluegun/toolbox')
 const yaml = require('js-yaml')
 const { getGraphTsVersion } = require('./util/versions')
+const { loadManifest } = require('./util/load-manifest')
 
 // If any of the manifest apiVersions are 0.0.1, replace them with 0.0.2
 module.exports = {
@@ -18,7 +19,7 @@ module.exports = {
       return 'graph-ts dependency not installed yet'
     }
 
-    let manifest = yaml.safeLoad(fs.readFileSync(manifestFile, 'utf-8'))
+    let manifest = loadManifest(manifestFile)
     return (
       // Only migrate if the graph-ts version is > 0.5.1...
       semver.gt(graphTsVersion, '0.5.1') &&

--- a/src/migrations/mapping_api_version_0_0_2.js
+++ b/src/migrations/mapping_api_version_0_0_2.js
@@ -1,7 +1,6 @@
-const fs = require('fs-extra')
 const semver = require('semver')
 const toolbox = require('gluegun/toolbox')
-const yaml = require('js-yaml')
+const { loadManifest } = require('./util/load-manifest')
 const { getGraphTsVersion } = require('./util/versions')
 
 // If any of the manifest apiVersions are 0.0.2, replace them with 0.0.3
@@ -18,7 +17,7 @@ module.exports = {
       return 'graph-ts dependency not installed yet'
     }
 
-    let manifest = yaml.safeLoad(fs.readFileSync(manifestFile, 'utf-8'))
+    let manifest = loadManifest(manifestFile)
     return (
       // Only migrate if the graph-ts version is > 0.12.0...
       semver.gt(graphTsVersion, '0.12.0') &&

--- a/src/migrations/mapping_api_version_0_0_3.js
+++ b/src/migrations/mapping_api_version_0_0_3.js
@@ -2,6 +2,7 @@ const fs = require('fs-extra')
 const semver = require('semver')
 const toolbox = require('gluegun/toolbox')
 const yaml = require('js-yaml')
+const { loadManifest } = require('./util/load-manifest')
 const { getGraphTsVersion } = require('./util/versions')
 
 // If any of the manifest apiVersions are 0.0.3, replace them with 0.0.4
@@ -18,7 +19,7 @@ module.exports = {
       return 'graph-ts dependency not installed yet'
     }
 
-    let manifest = yaml.safeLoad(fs.readFileSync(manifestFile, 'utf-8'))
+    let manifest = loadManifest(manifestFile)
     return (
       // Only migrate if the graph-ts version is > 0.17.0...
       semver.gt(graphTsVersion, '0.17.0') &&

--- a/src/migrations/spec_version_0_0_2.js
+++ b/src/migrations/spec_version_0_0_2.js
@@ -1,13 +1,14 @@
 const fs = require('fs-extra')
 const toolbox = require('gluegun/toolbox')
 const yaml = require('js-yaml')
+const { loadManifest } = require('./util/load-manifest')
 
 // Spec version to 0.0.2 uses top level templates. graph-cli no longer supports
 // 0.0.1 which used nested templates.
 module.exports = {
   name: 'Bump mapping specVersion from 0.0.1 to 0.0.2',
   predicate: async ({ sourceDir, manifestFile }) => {
-    let manifest = yaml.safeLoad(fs.readFileSync(manifestFile, 'utf-8'))
+    let manifest = loadManifest(manifestFile)
     return (
       manifest &&
       typeof manifest === 'object' &&

--- a/src/migrations/util/load-manifest.js
+++ b/src/migrations/util/load-manifest.js
@@ -1,6 +1,6 @@
 const fs = require('fs-extra')
 const path = require('path')
-const yaml = require('yaml')
+const yaml = require('js-yaml')
 
 function loadManifest(manifestFile) {
   if(manifestFile.match(/.js$/)) {

--- a/src/migrations/util/load-manifest.js
+++ b/src/migrations/util/load-manifest.js
@@ -1,0 +1,15 @@
+const fs = require('fs-extra')
+const path = require('path')
+
+function loadManifest(manifestFile) {
+  try {
+    return require(path.resolve(manifestFile))
+  }
+  catch(_) {
+    return yaml.safeLoad(fs.readFileSync(manifestFile, 'utf-8'))
+  }
+}
+
+module.exports = {
+  loadManifest
+}

--- a/src/migrations/util/load-manifest.js
+++ b/src/migrations/util/load-manifest.js
@@ -1,11 +1,12 @@
 const fs = require('fs-extra')
 const path = require('path')
+const yaml = require('yaml')
 
 function loadManifest(manifestFile) {
-  try {
+  if(manifestFile.match(/.js$/)) {
     return require(path.resolve(manifestFile))
   }
-  catch(_) {
+  else {
     return yaml.safeLoad(fs.readFileSync(manifestFile, 'utf-8'))
   }
 }

--- a/src/subgraph.js
+++ b/src/subgraph.js
@@ -423,9 +423,10 @@ More than one template named '${name}', template names must be unique.`,
     // Load and validate the manifest
     let data = null
 
-    try {
+    if(filename.match(/.js$/)) {
       data = require(path.resolve(filename))
-    } catch(_) {
+    }
+    else {
       data = yaml.parse(fs.readFileSync(filename, 'utf-8'))
     }
 

--- a/src/subgraph.js
+++ b/src/subgraph.js
@@ -421,7 +421,13 @@ More than one template named '${name}', template names must be unique.`,
 
   static load(filename, { skipValidation } = { skipValidation: false }) {
     // Load and validate the manifest
-    let data = yaml.parse(fs.readFileSync(filename, 'utf-8'))
+    let data = null
+
+    try {
+      data = require(path.resolve(filename))
+    } catch(_) {
+      data = yaml.parse(fs.readFileSync(filename, 'utf-8'))
+    }
 
     // Helper to resolve files relative to the subgraph manifest
     let resolveFile = maybeRelativeFile =>


### PR DESCRIPTION
in order to use the same subgraph for multiple neworks (ex. mainnet, kovan, mainnet-ovm, etc.), it is currently
necessary to construct a fresh subgraph manifest for each network and supply them individually.

this PR is a slight modification to the CLI in order to resolve the manifest definition from a JS file. as long
as the javascript resolves its `module.exports` to the JSON of the manifest, custom code can be used to generate
the appropriate manifest

this should not break any existing compatibility with YAML or JSON loading.