### PR TITLE
Use better the Node.js async API

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "pkginfo": "^0.4.1",
     "prettier": "^1.13.5",
     "request": "^2.88.0",
-    "tmp": "^0.1.0",
+    "tmp-promise": "^3.0.2",
     "yaml": "^1.5.1"
   },
   "optionalDependencies": {

--- a/src/codegen/abi.test.js
+++ b/src/codegen/abi.test.js
@@ -11,12 +11,12 @@ let abi
 let generatedTypes
 
 describe('ABI code generation', () => {
-  beforeAll(() => {
-    tempdir = fs.mkdtempSync('abi-codegen')
+  beforeAll(async () => {
+    tempdir = await fs.mkdtemp('abi-codegen')
 
     try {
       let filename = path.join(tempdir, 'ABI.json')
-      fs.writeFileSync(
+      await fs.writeFile(
         filename,
         JSON.stringify([
           {
@@ -170,12 +170,12 @@ describe('ABI code generation', () => {
       let codegen = new AbiCodeGenerator(abi)
       generatedTypes = codegen.generateTypes()
     } finally {
-      fs.removeSync(tempdir)
+      await fs.remove(tempdir)
     }
   })
 
-  afterAll(() => {
-    fs.removeSync(tempdir)
+  afterAll(async () => {
+    await fs.remove(tempdir)
   })
 
   describe('Generated types', () => {

--- a/src/commands/test.js
+++ b/src/commands/test.js
@@ -2,7 +2,7 @@ const chalk = require('chalk')
 const compose = require('docker-compose')
 const http = require('http')
 const net = require('net')
-const tmp = require('tmp')
+const tmp = require('tmp-promise')
 const Docker = require('dockerode')
 const path = require('path')
 const stripAnsi = require('strip-ansi')
@@ -107,7 +107,7 @@ module.exports = {
     }
 
     // Create temporary directory to operate in
-    let tempdir = tmp.dirSync({ prefix: 'graph-test', unsafeCleanup: true }).name
+    let { path: tempdir } = await tmp.dir({ prefix: 'graph-test', unsafeCleanup: true })
     try {
       await configureTestEnvironment(toolbox, tempdir, composeFile, nodeImage)
     } catch (e) {

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -587,7 +587,7 @@ class Compiler {
     let alreadyUploaded = uploadedFiles.has(uploadCacheKey)
 
     if (!alreadyUploaded) {
-      let content = Buffer.from(fs.readFileSync(absoluteFile), 'utf-8')
+      let content = Buffer.from(await fs.readFile(absoluteFile), 'utf-8')
       let hash = await this._uploadToIPFS({
         path: path.relative(this.options.outputDir, absoluteFile),
         content: content,

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -490,7 +490,7 @@ class Compiler {
         // Write the subgraph manifest itself
         let outputFilename = path.join(this.options.outputDir, 'subgraph.yaml')
         step(spinner, 'Write subgraph manifest', this.displayPath(outputFilename))
-        Subgraph.write(subgraph, outputFilename)
+        await Subgraph.write(subgraph, outputFilename)
 
         return subgraph
       },

--- a/src/migrations/mapping_api_version_0_0_1.js
+++ b/src/migrations/mapping_api_version_0_0_1.js
@@ -12,14 +12,14 @@ module.exports = {
     // Obtain the graph-ts version, if possible
     let graphTsVersion
     try {
-      graphTsVersion = getGraphTsVersion(sourceDir)
+      graphTsVersion = await getGraphTsVersion(sourceDir)
     } catch (_) {
       // If we cannot obtain the version, return a hint that the graph-ts
       // hasn't been installed yet
       return 'graph-ts dependency not installed yet'
     }
 
-    let manifest = loadManifest(manifestFile)
+    let manifest = await loadManifest(manifestFile)
     return (
       // Only migrate if the graph-ts version is > 0.5.1...
       semver.gt(graphTsVersion, '0.5.1') &&

--- a/src/migrations/mapping_api_version_0_0_2.js
+++ b/src/migrations/mapping_api_version_0_0_2.js
@@ -10,14 +10,14 @@ module.exports = {
     // Obtain the graph-ts version, if possible
     let graphTsVersion
     try {
-      graphTsVersion = getGraphTsVersion(sourceDir)
+      graphTsVersion = await getGraphTsVersion(sourceDir)
     } catch (_) {
       // If we cannot obtain the version, return a hint that the graph-ts
       // hasn't been installed yet
       return 'graph-ts dependency not installed yet'
     }
 
-    let manifest = loadManifest(manifestFile)
+    let manifest = await loadManifest(manifestFile)
     return (
       // Only migrate if the graph-ts version is > 0.12.0...
       semver.gt(graphTsVersion, '0.12.0') &&

--- a/src/migrations/mapping_api_version_0_0_3.js
+++ b/src/migrations/mapping_api_version_0_0_3.js
@@ -12,14 +12,14 @@ module.exports = {
     // Obtain the graph-ts version, if possible
     let graphTsVersion
     try {
-      graphTsVersion = getGraphTsVersion(sourceDir)
+      graphTsVersion = await getGraphTsVersion(sourceDir)
     } catch (_) {
       // If we cannot obtain the version, return a hint that the graph-ts
       // hasn't been installed yet
       return 'graph-ts dependency not installed yet'
     }
 
-    let manifest = loadManifest(manifestFile)
+    let manifest = await loadManifest(manifestFile)
     return (
       // Only migrate if the graph-ts version is > 0.17.0...
       semver.gt(graphTsVersion, '0.17.0') &&

--- a/src/migrations/spec_version_0_0_2.js
+++ b/src/migrations/spec_version_0_0_2.js
@@ -8,7 +8,7 @@ const { loadManifest } = require('./util/load-manifest')
 module.exports = {
   name: 'Bump mapping specVersion from 0.0.1 to 0.0.2',
   predicate: async ({ sourceDir, manifestFile }) => {
-    let manifest = loadManifest(manifestFile)
+    let manifest = await loadManifest(manifestFile)
     return (
       manifest &&
       typeof manifest === 'object' &&

--- a/src/migrations/util/load-manifest.js
+++ b/src/migrations/util/load-manifest.js
@@ -2,15 +2,15 @@ const fs = require('fs-extra')
 const path = require('path')
 const yaml = require('js-yaml')
 
-function loadManifest(manifestFile) {
+async function loadManifest(manifestFile) {
   if(manifestFile.match(/.js$/)) {
     return require(path.resolve(manifestFile))
   }
   else {
-    return yaml.safeLoad(fs.readFileSync(manifestFile, 'utf-8'))
+    return yaml.safeLoad(await fs.readFile(manifestFile, 'utf-8'))
   }
 }
 
 module.exports = {
-  loadManifest
+  loadManifest,
 }

--- a/src/migrations/util/versions.js
+++ b/src/migrations/util/versions.js
@@ -2,7 +2,7 @@ const path = require('path')
 const fs = require('fs-extra')
 const yaml = require('js-yaml')
 
-const getGraphTsVersion = sourceDir => {
+const getGraphTsVersion = async sourceDir => {
   let pkgJsonFile = path.join(
     sourceDir,
     'node_modules',
@@ -10,11 +10,11 @@ const getGraphTsVersion = sourceDir => {
     'graph-ts',
     'package.json',
   )
-  let data = fs.readFileSync(pkgJsonFile)
+  let data = await fs.readFile(pkgJsonFile)
   let jsonData = JSON.parse(data)
   return jsonData.version
 }
 
 module.exports = {
-  getGraphTsVersion: getGraphTsVersion,
+  getGraphTsVersion,
 }

--- a/src/scaffold.js
+++ b/src/scaffold.js
@@ -314,19 +314,21 @@ const generateScaffold = async (
 
 const writeScaffoldDirectory = async (scaffold, directory, spinner) => {
   // Create directory itself
-  fs.mkdirsSync(directory)
+  await fs.mkdirs(directory)
 
-  Object.keys(scaffold).forEach(basename => {
+  let promises = Object.keys(scaffold).map(async basename => {
     let content = scaffold[basename]
     let filename = path.join(directory, basename)
 
     // Write file or recurse into subdirectory
     if (typeof content === 'string') {
-      fs.writeFileSync(filename, content, { encoding: 'utf-8' })
+      await fs.writeFile(filename, content, { encoding: 'utf-8' })
     } else {
       writeScaffoldDirectory(content, path.join(directory, basename), spinner)
     }
   })
+
+  await Promise.all(promises)
 }
 
 const writeScaffold = async (scaffold, directory, spinner) => {

--- a/src/schema.js
+++ b/src/schema.js
@@ -15,8 +15,8 @@ module.exports = class Schema {
     return new SchemaCodeGenerator(this)
   }
 
-  static load(filename) {
-    let document = fs.readFileSync(filename, 'utf-8')
+  static async load(filename) {
+    let document = await fs.readFile(filename, 'utf-8')
     let ast = graphql.parse(document)
     return new Schema(filename, document, immutable.fromJS(ast))
   }

--- a/src/subgraph.js
+++ b/src/subgraph.js
@@ -39,10 +39,10 @@ const buildCombinedWarning = (filename, warnings) =>
     : null
 
 module.exports = class Subgraph {
-  static validate(data, { resolveFile }) {
+  static async validate(data, { resolveFile }) {
     // Parse the default subgraph schema
     let schema = graphql.parse(
-      fs.readFileSync(path.join(__dirname, '..', 'manifest-schema.graphql'), 'utf-8'),
+      await fs.readFile(path.join(__dirname, '..', 'manifest-schema.graphql'), 'utf-8'),
     )
 
     // Obtain the root `SubgraphManifest` type from the schema
@@ -419,7 +419,7 @@ More than one template named '${name}', template names must be unique.`,
     return yaml.stringify(manifest.toJS())
   }
 
-  static load(filename, { skipValidation } = { skipValidation: false }) {
+  static async load(filename, { skipValidation } = { skipValidation: false }) {
     // Load and validate the manifest
     let data = null
 
@@ -427,14 +427,14 @@ More than one template named '${name}', template names must be unique.`,
       data = require(path.resolve(filename))
     }
     else {
-      data = yaml.parse(fs.readFileSync(filename, 'utf-8'))
+      data = yaml.parse(await fs.readFile(filename, 'utf-8'))
     }
 
     // Helper to resolve files relative to the subgraph manifest
     let resolveFile = maybeRelativeFile =>
       path.resolve(path.dirname(filename), maybeRelativeFile)
 
-    let manifestErrors = Subgraph.validate(data, { resolveFile })
+    let manifestErrors = await Subgraph.validate(data, { resolveFile })
     if (manifestErrors.size > 0) {
       throwCombinedError(filename, manifestErrors)
     }
@@ -476,7 +476,7 @@ More than one template named '${name}', template names must be unique.`,
     }
   }
 
-  static write(manifest, filename) {
-    fs.writeFileSync(filename, Subgraph.dump(manifest))
+  static async write(manifest, filename) {
+    await fs.writeFile(filename, Subgraph.dump(manifest))
   }
 }

--- a/src/type-generator.js
+++ b/src/type-generator.js
@@ -187,8 +187,8 @@ module.exports = class TypeGenerator {
         `${abi.abi.name}.ts`,
       )
       step(spinner, `Write types to`, this.displayPath(outputFile))
-      fs.mkdirsSync(path.dirname(outputFile))
-      fs.writeFileSync(outputFile, code)
+      await fs.mkdirs(path.dirname(outputFile))
+      await fs.writeFile(outputFile, code)
     } catch (e) {
       throw Error(`Failed to generate types for contract ABI: ${e.message}`)
     }
@@ -223,8 +223,8 @@ module.exports = class TypeGenerator {
         `${abi.abi.name}.ts`,
       )
       step(spinner, `Write types to`, this.displayPath(outputFile))
-      fs.mkdirsSync(path.dirname(outputFile))
-      fs.writeFileSync(outputFile, code)
+      await fs.mkdirs(path.dirname(outputFile))
+      await fs.writeFile(outputFile, code)
     } catch (e) {
       throw Error(`Failed to generate types for data source template ABI: ${e.message}`)
     }
@@ -266,8 +266,8 @@ module.exports = class TypeGenerator {
 
         let outputFile = path.join(this.options.outputDir, 'schema.ts')
         step(spinner, 'Write types to', this.displayPath(outputFile))
-        fs.mkdirsSync(path.dirname(outputFile))
-        fs.writeFileSync(outputFile, code)
+        await fs.mkdirs(path.dirname(outputFile))
+        await fs.writeFile(outputFile, code)
       },
     )
   }
@@ -306,8 +306,8 @@ module.exports = class TypeGenerator {
 
           let outputFile = path.join(this.options.outputDir, 'templates.ts')
           step(spinner, `Write types for templates to`, this.displayPath(outputFile))
-          fs.mkdirsSync(path.dirname(outputFile))
-          fs.writeFileSync(outputFile, code)
+          await fs.mkdirs(path.dirname(outputFile))
+          await fs.writeFile(outputFile, code)
         }
       },
     )

--- a/yarn.lock
+++ b/yarn.lock
@@ -5567,6 +5567,13 @@ through2@^3.0.0, through2@^3.0.1:
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
 
+tmp-promise@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/tmp-promise/-/tmp-promise-3.0.2.tgz#6e933782abff8b00c3119d63589ca1fb9caaa62a"
+  integrity sha512-OyCLAKU1HzBjL6Ev3gxUeraJNlbNingmi8IrHHEsYH8LTmEuhvYfqvhn2F/je+mjf4N58UmZ96OMEy1JanSCpA==
+  dependencies:
+    tmp "^0.2.0"
+
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -5574,12 +5581,12 @@ tmp@^0.0.33:
   dependencies:
     os-tmpdir "~1.0.2"
 
-tmp@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.1.0.tgz#ee434a4e22543082e294ba6201dcc6eafefa2877"
-  integrity sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==
+tmp@^0.2.0:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.1.tgz#8457fc3037dcf4719c251367a1af6500ee1ccf14"
+  integrity sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==
   dependencies:
-    rimraf "^2.6.3"
+    rimraf "^3.0.0"
 
 tmpl@1.0.x:
   version "1.0.4"


### PR DESCRIPTION
By reading this project code I was intrigued that a lot of IO operations were using synchronous APIs. Then, I searched for every `Sync` in here and tried to look were the function was used to check if it could use the `Async` version instead.

You might think/ask: why do this change?

It's not guaranteed to have performance improvements with this PR, **however**, by using Node.js asynchronous APIs, we can make sure we are at least giving to the "engine" all the information it needs to do other work while some code is waiting for IO.