### PR TITLE
compiler: pass absolute path to _validateMappingContent

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -241,7 +241,7 @@ class Compiler {
       let baseDir = this.sourceDir
       let absoluteMappingPath = path.resolve(baseDir, mappingPath)
       let inputFile = path.relative(baseDir, absoluteMappingPath)
-      this._validateMappingContent(inputFile)
+      this._validateMappingContent(absoluteMappingPath)
 
       // If the file has already been compiled elsewhere, just use that output
       // file and return early
@@ -322,7 +322,7 @@ class Compiler {
       let baseDir = this.sourceDir
       let absoluteMappingPath = path.resolve(baseDir, mappingPath)
       let inputFile = path.relative(baseDir, absoluteMappingPath)
-      this._validateMappingContent(inputFile)
+      this._validateMappingContent(absoluteMappingPath)
 
       // If the file has already been compiled elsewhere, just use that output
       // file and return early


### PR DESCRIPTION
This fixes #718 and doesn't do any harm but as mentioned in the issue, the actual problem might be related to `path.relative`, one line before. So maybe you want to close this PR and fix this instead. I just wasn't able to do so without breaking the rest of the process.