### PR TITLE
Bump graph-ts to 0.22.0-alpha.1

### DIFF
--- a/examples/basic-event-handlers/package.json
+++ b/examples/basic-event-handlers/package.json
@@ -9,7 +9,7 @@
     "deploy-test": "../../bin/graph deploy test/basic-event-handlers --version-label v0.0.1 --ipfs http://localhost:15001 --node http://127.0.0.1:18020"
   },
   "devDependencies": {
-    "@graphprotocol/graph-ts": "0.22.0-alpha.0",
+    "@graphprotocol/graph-ts": "0.22.0-alpha.1",
     "apollo-fetch": "^0.7.0"
   },
   "dependencies": {

--- a/examples/basic-event-handlers/yarn.lock
+++ b/examples/basic-event-handlers/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@graphprotocol/graph-ts@0.22.0-alpha.0":
-  version "0.22.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-ts/-/graph-ts-0.22.0-alpha.0.tgz#7bb9134269632cbbd7de677872f4c4b8b8bed94b"
-  integrity sha512-iabDkebfIpScK3svM4uJuYmdtjwNRUcXNaRRXj4IUbMy5+uoyxilSFUdBVC2yUNQzo47XQj9FAYHANrGija7HQ==
+"@graphprotocol/graph-ts@0.22.0-alpha.1":
+  version "0.22.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-ts/-/graph-ts-0.22.0-alpha.1.tgz#b10aa8772a155770e2e9e529cd246bc3e0daf42f"
+  integrity sha512-Vkvb9mPX4qAZCVm0fGNZtD9nHCZ8jKsAlvewgIZw1b4/68RhHRup2l2m9VDCvKPmU1QsxALKDLYPm4XXrdH1AA==
   dependencies:
     assemblyscript "0.19.10"
 

--- a/examples/example-subgraph/package.json
+++ b/examples/example-subgraph/package.json
@@ -7,7 +7,7 @@
     "build-wast": "../../bin/graph build -t wast subgraph.yaml"
   },
   "devDependencies": {
-    "@graphprotocol/graph-ts": "0.22.0-alpha.0"
+    "@graphprotocol/graph-ts": "0.22.0-alpha.1"
   },
   "resolutions": {
     "assemblyscript": "0.19.10"

--- a/examples/example-subgraph/yarn.lock
+++ b/examples/example-subgraph/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@graphprotocol/graph-ts@0.22.0-alpha.0":
-  version "0.22.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-ts/-/graph-ts-0.22.0-alpha.0.tgz#7bb9134269632cbbd7de677872f4c4b8b8bed94b"
-  integrity sha512-iabDkebfIpScK3svM4uJuYmdtjwNRUcXNaRRXj4IUbMy5+uoyxilSFUdBVC2yUNQzo47XQj9FAYHANrGija7HQ==
+"@graphprotocol/graph-ts@0.22.0-alpha.1":
+  version "0.22.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-ts/-/graph-ts-0.22.0-alpha.1.tgz#b10aa8772a155770e2e9e529cd246bc3e0daf42f"
+  integrity sha512-Vkvb9mPX4qAZCVm0fGNZtD9nHCZ8jKsAlvewgIZw1b4/68RhHRup2l2m9VDCvKPmU1QsxALKDLYPm4XXrdH1AA==
   dependencies:
     assemblyscript "0.19.10"
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "test:validation": "jest tests/cli/validation.test.js --verbose",
     "release:patch": "npm version patch && npm publish && git push origin master && git push --tags",
     "release:minor": "npm version minor && npm publish && git push origin master && git push --tags",
-    "release:alpha:minor": "npm version preminor --preid alpha && npm publish --tag alpha && git push origin master && git push --tags"
+    "release:alpha:minor": "npm version preminor --preid alpha && npm publish --tag alpha && git push origin master && git push --tags",
+    "release:alpha:prerelease": "npm version prerelease --preid alpha && npm publish --tag alpha && git push origin master && git push --tags"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphprotocol/graph-cli",
-  "version": "0.22.0-alpha.0",
+  "version": "0.22.0-alpha.1",
   "description": "CLI for building for and deploying to The Graph",
   "dependencies": {
     "assemblyscript": "0.19.10",

--- a/src/scaffold.js
+++ b/src/scaffold.js
@@ -41,7 +41,7 @@ const generatePackageJson = ({ subgraphName, node }) =>
       },
       dependencies: {
         '@graphprotocol/graph-cli': `${module.exports.version}`,
-        '@graphprotocol/graph-ts': `0.22.0-alpha.0`,
+        '@graphprotocol/graph-ts': `0.22.0-alpha.1`,
       },
     }),
     { parser: 'json' },


### PR DESCRIPTION
This bump basically includes some constructors for `ethereum` classes.

We've added those so that we could remove runtime checks created by the `!` on class properties.