### PR TITLE
Migrations for specVersion 0.0.4

### DIFF
--- a/src/migrations.js
+++ b/src/migrations.js
@@ -8,6 +8,7 @@ const MIGRATIONS = [
   require('./migrations/mapping_api_version_0_0_5'),
   require('./migrations/mapping_api_version_0_0_6'),
   require('./migrations/spec_version_0_0_2'),
+  require('./migrations/spec_version_0_0_3'),
   require('./migrations/spec_version_0_0_4'),
 ]
 

--- a/src/migrations/spec_version_0_0_2.js
+++ b/src/migrations/spec_version_0_0_2.js
@@ -6,7 +6,7 @@ const { loadManifest } = require('./util/load-manifest')
 // Spec version to 0.0.2 uses top level templates. graph-cli no longer supports
 // 0.0.1 which used nested templates.
 module.exports = {
-  name: 'Bump mapping specVersion from 0.0.1 to 0.0.2',
+  name: 'Bump manifest specVersion from 0.0.1 to 0.0.2',
   predicate: async ({ sourceDir, manifestFile }) => {
     let manifest = await loadManifest(manifestFile)
     return (

--- a/src/migrations/spec_version_0_0_3.js
+++ b/src/migrations/spec_version_0_0_3.js
@@ -1,0 +1,29 @@
+const fs = require('fs-extra')
+const toolbox = require('gluegun/toolbox')
+const yaml = require('js-yaml')
+const { loadManifest } = require('./util/load-manifest')
+
+// Spec version 0.0.4 uses feature management, but features are
+// detected and validated by the graph-node instance during subgraph
+// deployment.
+//
+// Also, we skip spec version 0.0.3, which is considered invalid and
+// non-canonical.
+module.exports = {
+  name: 'Bump manifest specVersion from 0.0.2 to 0.0.4',
+  predicate: async ({ sourceDir, manifestFile }) => {
+    let manifest = await loadManifest(manifestFile)
+    return (
+      manifest &&
+      typeof manifest === 'object' &&
+      manifest.specVersion &&
+      (manifest.specVersion === '0.0.2' || manifest.specVersion === '0.0.3')
+    )
+  },
+  apply: async ({ manifestFile }) => {
+    await toolbox.patching.patch(manifestFile, {
+      insert: 'specVersion: 0.0.4',
+      replace: new RegExp(`specVersion: ['"]?0.0.[23]['"]?`),
+    })
+  },
+}


### PR DESCRIPTION
This PR adds a migration for upgrading `specVersion` 0.0.2 (and the non-canonical 0.0.3) to 0.0.4.

This new specification version enforces that all used features must be listed in the `features` key of the subgraph's manifest.

Since feature detection and validation occur inside a `graph-node` instance during deploy time, subgraphs that use any feature are expected to end with an invalid `subgraph.yml`, as `graph-cli` won't be able to infer and fill the `features` section of the manifest file automatically.