### PR TITLE
Release 0.22.0-alpha.3

### DIFF
--- a/examples/basic-event-handlers/package.json
+++ b/examples/basic-event-handlers/package.json
@@ -9,7 +9,7 @@
     "deploy-test": "../../bin/graph deploy test/basic-event-handlers --version-label v0.0.1 --ipfs http://localhost:15001 --node http://127.0.0.1:18020"
   },
   "devDependencies": {
-    "@graphprotocol/graph-ts": "0.22.0-alpha.2",
+    "@graphprotocol/graph-ts": "0.22.0-alpha.3",
     "apollo-fetch": "^0.7.0"
   },
   "dependencies": {

--- a/examples/basic-event-handlers/yarn.lock
+++ b/examples/basic-event-handlers/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@graphprotocol/graph-ts@0.22.0-alpha.2":
-  version "0.22.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-ts/-/graph-ts-0.22.0-alpha.2.tgz#df2200a20bb8ceaeb835ba905430cf75b37a4874"
-  integrity sha512-UeoNfZLz7S4OAby/2K0zt3lGfcLqa8viujH6D5gjhDjFWTd6TiLb60OToFv7963YBHHdyjeEfIlmm2IuXSQeLA==
+"@graphprotocol/graph-ts@0.22.0-alpha.3":
+  version "0.22.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-ts/-/graph-ts-0.22.0-alpha.3.tgz#925e564adf65b512aad2809a3c49e10f4fe03a8e"
+  integrity sha512-pYYwMbWxshyKgWswAxBh0ebLSzeBYp0OEREZJy7M9yuTTKTNJNeSYoC3KZOhZnh3D5otre2LLQOd5cL8oaVylQ==
   dependencies:
     assemblyscript "0.19.10"
 

--- a/examples/example-subgraph/package.json
+++ b/examples/example-subgraph/package.json
@@ -7,7 +7,7 @@
     "build-wast": "../../bin/graph build -t wast subgraph.yaml"
   },
   "devDependencies": {
-    "@graphprotocol/graph-ts": "0.22.0-alpha.2"
+    "@graphprotocol/graph-ts": "0.22.0-alpha.3"
   },
   "resolutions": {
     "assemblyscript": "0.19.10"

--- a/examples/example-subgraph/yarn.lock
+++ b/examples/example-subgraph/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@graphprotocol/graph-ts@0.22.0-alpha.2":
-  version "0.22.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-ts/-/graph-ts-0.22.0-alpha.2.tgz#df2200a20bb8ceaeb835ba905430cf75b37a4874"
-  integrity sha512-UeoNfZLz7S4OAby/2K0zt3lGfcLqa8viujH6D5gjhDjFWTd6TiLb60OToFv7963YBHHdyjeEfIlmm2IuXSQeLA==
+"@graphprotocol/graph-ts@0.22.0-alpha.3":
+  version "0.22.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-ts/-/graph-ts-0.22.0-alpha.3.tgz#925e564adf65b512aad2809a3c49e10f4fe03a8e"
+  integrity sha512-pYYwMbWxshyKgWswAxBh0ebLSzeBYp0OEREZJy7M9yuTTKTNJNeSYoC3KZOhZnh3D5otre2LLQOd5cL8oaVylQ==
   dependencies:
     assemblyscript "0.19.10"
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphprotocol/graph-cli",
-  "version": "0.22.0-alpha.2",
+  "version": "0.22.0-alpha.3",
   "description": "CLI for building for and deploying to The Graph",
   "dependencies": {
     "assemblyscript": "0.19.10",

--- a/src/scaffold.js
+++ b/src/scaffold.js
@@ -41,7 +41,7 @@ const generatePackageJson = ({ subgraphName, node }) =>
       },
       dependencies: {
         '@graphprotocol/graph-cli': `${module.exports.version}`,
-        '@graphprotocol/graph-ts': `0.22.0-alpha.2`,
+        '@graphprotocol/graph-ts': `0.22.0-alpha.3`,
       },
     }),
     { parser: 'json' },


### PR DESCRIPTION
- Bump graph-ts to 0.22.0-alpha.3, which contains:
  - New assertions on operator overloading: https://github.com/graphprotocol/graph-ts/pull/204
- Bump graph-cli to 0.22.0-alpha.3, which contains:
  - deriveFrom bug fix #739
  - matchstick testing framework #731