### PR TITLE
chore: Bump graph-ts to 0.22.1

### DIFF
--- a/examples/basic-event-handlers/package.json
+++ b/examples/basic-event-handlers/package.json
@@ -9,7 +9,7 @@
     "deploy-test": "../../bin/graph deploy test/basic-event-handlers --version-label v0.0.1 --ipfs http://localhost:15001 --node http://127.0.0.1:18020"
   },
   "devDependencies": {
-    "@graphprotocol/graph-ts": "0.22.0",
+    "@graphprotocol/graph-ts": "0.22.1",
     "apollo-fetch": "^0.7.0"
   },
   "dependencies": {

--- a/examples/example-subgraph/package.json
+++ b/examples/example-subgraph/package.json
@@ -7,7 +7,7 @@
     "build-wast": "../../bin/graph build -t wast subgraph.yaml"
   },
   "devDependencies": {
-    "@graphprotocol/graph-ts": "0.22.0"
+    "@graphprotocol/graph-ts": "0.22.1"
   },
   "resolutions": {
     "assemblyscript": "0.19.10"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphprotocol/graph-cli",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "CLI for building for and deploying to The Graph",
   "dependencies": {
     "assemblyscript": "0.19.10",

--- a/src/scaffold.js
+++ b/src/scaffold.js
@@ -41,7 +41,7 @@ const generatePackageJson = ({ subgraphName, node }) =>
       },
       dependencies: {
         '@graphprotocol/graph-cli': `${module.exports.version}`,
-        '@graphprotocol/graph-ts': `0.22.0`,
+        '@graphprotocol/graph-ts': `0.22.1`,
       },
     }),
     { parser: 'json' },


### PR DESCRIPTION
This should fix the upcast error that happened on a toTupleArray call.

graph-ts related PR: https://github.com/graphprotocol/graph-ts/pull/208