### PR TITLE
init, deploy: Allow Studio to have Rinkeby subgraphs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphprotocol/graph-cli",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "description": "CLI for building for and deploying to The Graph",
   "dependencies": {
     "assemblyscript": "0.19.10",

--- a/src/command-helpers/studio.js
+++ b/src/command-helpers/studio.js
@@ -1,12 +1,15 @@
+const allowedStudioNetworks = ['mainnet', 'rinkeby']
+
 const validateStudioNetwork = ({ studio, product, network }) => {
   let isStudio = studio || product === 'subgraph-studio'
-  let isEthereumMainnet = network === 'mainnet'
+  let isAllowedNetwork = allowedStudioNetworks.includes(network)
 
-  if (isStudio && !isEthereumMainnet) {
-    throw new Error(`Non Ethereum mainnet subgraphs should not be deployed to the studio`)
+  if (isStudio && !isAllowedNetwork) {
+    throw new Error(`The Subgraph Studio only allows subgraphs for these networks: ${allowedStudioNetworks.join(', ')}`)
   }
 }
 
 module.exports = {
+  allowedStudioNetworks,
   validateStudioNetwork,
 }

--- a/src/command-helpers/studio.test.js
+++ b/src/command-helpers/studio.test.js
@@ -1,4 +1,4 @@
-const { validateStudioNetwork } = require('./studio')
+const { validateStudioNetwork, allowedStudioNetworks } = require('./studio')
 
 describe('Version Command Helpers', () => {
   describe('validateStudioNetwork', () => {
@@ -9,7 +9,7 @@ describe('Version Command Helpers', () => {
           network: 'mainnet',
         }))
           .not
-          .toThrow(new Error('Non Ethereum mainnet subgraphs should not be deployed to the studio'))
+          .toThrow(new Error(`The Subgraph Studio only allows subgraphs for these networks: ${allowedStudioNetworks.join(', ')}`))
       })
 
       test("And it's NOT Ethereum mainnet", () => {
@@ -17,18 +17,18 @@ describe('Version Command Helpers', () => {
           product: 'subgraph-studio',
           network: 'xdai',
         }))
-          .toThrow(new Error('Non Ethereum mainnet subgraphs should not be deployed to the studio'))
+          .toThrow(new Error(`The Subgraph Studio only allows subgraphs for these networks: ${allowedStudioNetworks.join(', ')}`))
       })
     })
 
     describe("When it's NOT studio", () => {
-      test("And it's Ethereum mainnet", () => {
+      test("And it's Rinkeby", () => {
         expect(() => validateStudioNetwork({
           studio: false,
-          network: 'mainnet',
+          network: 'rinkeby',
         }))
           .not
-          .toThrow(new Error('Non Ethereum mainnet subgraphs should not be deployed to the studio'))
+          .toThrow(new Error(`The Subgraph Studio only allows subgraphs for these networks: ${allowedStudioNetworks.join(', ')}`))
       })
 
       test("And it's NOT Ethereum mainnet", () => {
@@ -37,7 +37,7 @@ describe('Version Command Helpers', () => {
           network: 'xdai',
         }))
           .not
-          .toThrow(new Error('Non Ethereum mainnet subgraphs should not be deployed to the studio'))
+          .toThrow(new Error(`The Subgraph Studio only allows subgraphs for these networks: ${allowedStudioNetworks.join(', ')}`))
       })
     })
   })


### PR DESCRIPTION
When the Studio got launched, all networks were available for it, but it wasn't/isn't useful, because we only index Ethereum mainnet and Rinkeby for it.

So we've added the limitation just for Ethereum mainnet.
However Rinkeby was missing and this PR fixes the issue.