### PR TITLE
apiVersion 0.0.6

### DIFF
--- a/examples/basic-event-handlers/package.json
+++ b/examples/basic-event-handlers/package.json
@@ -9,7 +9,7 @@
     "deploy-test": "../../bin/graph deploy test/basic-event-handlers --version-label v0.0.1 --ipfs http://localhost:15001 --node http://127.0.0.1:18020"
   },
   "devDependencies": {
-    "@graphprotocol/graph-ts": "0.23.1",
+    "@graphprotocol/graph-ts": "0.24.0-alpha.0",
     "apollo-fetch": "^0.7.0"
   },
   "dependencies": {

--- a/examples/basic-event-handlers/yarn.lock
+++ b/examples/basic-event-handlers/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@graphprotocol/graph-ts@0.23.1":
-  version "0.23.1"
-  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-ts/-/graph-ts-0.23.1.tgz#76e595d26ec5672f3778b1d3830e4640a57aec1b"
-  integrity sha512-pipofvN1LlwLOXrS7IWy8hSBFZzVyVHdLXDpQskl9nKqdbb3chelj4JoVEzCl7klvomDpP84ngLpW17fBh5vww==
+"@graphprotocol/graph-ts@0.24.0-alpha.0":
+  version "0.24.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-ts/-/graph-ts-0.24.0-alpha.0.tgz#8fe2b09a123adc5a65c82b823a1cb2d99f3cce2b"
+  integrity sha512-PLhTMlFMoLZpTqJlKH5f+5VRN3yWmXfssVwWk7uauVeY8IuAWjWB3RNubS574q9uf0QjPKOacekXY5EKRWOzEA==
   dependencies:
     assemblyscript "0.19.10"
 

--- a/examples/example-subgraph/package.json
+++ b/examples/example-subgraph/package.json
@@ -7,7 +7,7 @@
     "build-wast": "../../bin/graph build -t wast subgraph.yaml"
   },
   "devDependencies": {
-    "@graphprotocol/graph-ts": "0.23.1"
+    "@graphprotocol/graph-ts": "0.24.0-alpha.0"
   },
   "resolutions": {
     "assemblyscript": "0.19.10"

--- a/examples/example-subgraph/yarn.lock
+++ b/examples/example-subgraph/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@graphprotocol/graph-ts@0.23.1":
-  version "0.23.1"
-  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-ts/-/graph-ts-0.23.1.tgz#76e595d26ec5672f3778b1d3830e4640a57aec1b"
-  integrity sha512-pipofvN1LlwLOXrS7IWy8hSBFZzVyVHdLXDpQskl9nKqdbb3chelj4JoVEzCl7klvomDpP84ngLpW17fBh5vww==
+"@graphprotocol/graph-ts@0.24.0-alpha.0":
+  version "0.24.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-ts/-/graph-ts-0.24.0-alpha.0.tgz#8fe2b09a123adc5a65c82b823a1cb2d99f3cce2b"
+  integrity sha512-PLhTMlFMoLZpTqJlKH5f+5VRN3yWmXfssVwWk7uauVeY8IuAWjWB3RNubS574q9uf0QjPKOacekXY5EKRWOzEA==
   dependencies:
     assemblyscript "0.19.10"
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphprotocol/graph-cli",
-  "version": "0.23.2",
+  "version": "0.24.0-alpha.0",
   "description": "CLI for building for and deploying to The Graph",
   "dependencies": {
     "assemblyscript": "0.19.10",

--- a/src/migrations/mapping_api_version_0_0_5.js
+++ b/src/migrations/mapping_api_version_0_0_5.js
@@ -1,0 +1,74 @@
+const fs = require('fs-extra')
+const semver = require('semver')
+const toolbox = require('gluegun/toolbox')
+const yaml = require('js-yaml')
+const { loadManifest } = require('./util/load-manifest')
+const { getGraphTsVersion } = require('./util/versions')
+
+// If any of the manifest apiVersions are 0.0.5, replace them with 0.0.6
+module.exports = {
+  name: 'Bump mapping apiVersion from 0.0.5 to 0.0.6',
+  predicate: async ({ sourceDir, manifestFile }) => {
+    // Obtain the graph-ts version, if possible
+    let graphTsVersion
+    try {
+      graphTsVersion = await getGraphTsVersion(sourceDir)
+    } catch (_) {
+      // If we cannot obtain the version, return a hint that the graph-ts
+      // hasn't been installed yet
+      return 'graph-ts dependency not installed yet'
+    }
+
+    let manifest = loadManifest(manifestFile)
+    return (
+      // Only migrate if the graph-ts version is >= 0.23.0...
+      // Coerce needed because we may be dealing with an alpha version
+      // and in the `semver` library this would not return true on equality.
+      semver.gte(semver.coerce(graphTsVersion), '0.23.0') &&
+      // ...and we have a manifest with mapping > apiVersion = 0.0.5
+      manifest &&
+      typeof manifest === 'object' &&
+      Array.isArray(manifest.dataSources) &&
+      (manifest.dataSources.reduce(
+        (hasOldMappings, dataSource) =>
+          hasOldMappings ||
+          (typeof dataSource === 'object' &&
+            dataSource.mapping &&
+            typeof dataSource.mapping === 'object' &&
+            dataSource.mapping.apiVersion === '0.0.5'),
+        false,
+      ) ||
+        (Array.isArray(manifest.templates) &&
+          manifest.templates.reduce(
+            (hasOldMappings, template) =>
+              hasOldMappings ||
+              (typeof template === 'object' &&
+                template.mapping &&
+                typeof template.mapping === 'object' &&
+                template.mapping.apiVersion === '0.0.5'),
+            false,
+          )))
+    )
+  },
+  apply: async ({ manifestFile }) => {
+    // Make sure we catch all variants; we could load the manifest
+    // and replace the values in the data structures here; unfortunately
+    // writing that back to the file messes with the formatting more than
+    // we'd like; that's why for now, we use a simple patching approach
+    await toolbox.patching.replace(
+      manifestFile,
+      new RegExp('apiVersion: 0.0.5', 'g'),
+      'apiVersion: 0.0.6',
+    )
+    await toolbox.patching.replace(
+      manifestFile,
+      new RegExp("apiVersion: '0.0.5'", 'g'),
+      "apiVersion: '0.0.6'",
+    )
+    await toolbox.patching.replace(
+      manifestFile,
+      new RegExp('apiVersion: "0.0.5"', 'g'),
+      'apiVersion: "0.0.6"',
+    )
+  },
+}

--- a/src/migrations/mapping_api_version_0_0_5.js
+++ b/src/migrations/mapping_api_version_0_0_5.js
@@ -24,7 +24,7 @@ module.exports = {
       // Only migrate if the graph-ts version is >= 0.23.0...
       // Coerce needed because we may be dealing with an alpha version
       // and in the `semver` library this would not return true on equality.
-      semver.gte(semver.coerce(graphTsVersion), '0.23.0') &&
+      semver.gte(semver.coerce(graphTsVersion), '0.24.0') &&
       // ...and we have a manifest with mapping > apiVersion = 0.0.5
       manifest &&
       typeof manifest === 'object' &&

--- a/src/scaffold.js
+++ b/src/scaffold.js
@@ -49,7 +49,7 @@ const generatePackageJson = ({ subgraphName, node }) =>
       },
       dependencies: {
         '@graphprotocol/graph-cli': graphCliVersion,
-        '@graphprotocol/graph-ts': `0.23.1`,
+        '@graphprotocol/graph-ts': `0.24.0-alpha.0`,
       },
     }),
     { parser: 'json' },


### PR DESCRIPTION
This PR adds:
- migrations for `apiVersion`, from `0.0.5` to `0.0.6`.
- bumps the version restriction on `build` and `deploy` commands to `graph-ts` (`0.23.0`) and `apiVersion` (`0.0.6`).
- bumps `graph-cli` version to `0.23.0`.
- bumps `graph-ts` versions on scaffolded code and examples to `0.23.0`.