### PR TITLE
0.23.1 - tsconfig.json for graph init's scaffold

### DIFF
--- a/examples/basic-event-handlers/package.json
+++ b/examples/basic-event-handlers/package.json
@@ -9,7 +9,7 @@
     "deploy-test": "../../bin/graph deploy test/basic-event-handlers --version-label v0.0.1 --ipfs http://localhost:15001 --node http://127.0.0.1:18020"
   },
   "devDependencies": {
-    "@graphprotocol/graph-ts": "0.22.1",
+    "@graphprotocol/graph-ts": "0.23.1",
     "apollo-fetch": "^0.7.0"
   },
   "dependencies": {

--- a/examples/basic-event-handlers/yarn.lock
+++ b/examples/basic-event-handlers/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@graphprotocol/graph-ts@0.22.1":
-  version "0.22.1"
-  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-ts/-/graph-ts-0.22.1.tgz#3189b2495b33497280f617316cce68074d48e236"
-  integrity sha512-T5xrHN0tHJwd7ZnSTLhk5hAL3rCIp6rJ40kBCrETnv1mfK9hVyoojJK6VtBQXTbLsYtKe4SYjjD0cdOsAR9QiA==
+"@graphprotocol/graph-ts@0.23.1":
+  version "0.23.1"
+  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-ts/-/graph-ts-0.23.1.tgz#76e595d26ec5672f3778b1d3830e4640a57aec1b"
+  integrity sha512-pipofvN1LlwLOXrS7IWy8hSBFZzVyVHdLXDpQskl9nKqdbb3chelj4JoVEzCl7klvomDpP84ngLpW17fBh5vww==
   dependencies:
     assemblyscript "0.19.10"
 

--- a/examples/example-subgraph/package.json
+++ b/examples/example-subgraph/package.json
@@ -7,7 +7,7 @@
     "build-wast": "../../bin/graph build -t wast subgraph.yaml"
   },
   "devDependencies": {
-    "@graphprotocol/graph-ts": "0.22.1"
+    "@graphprotocol/graph-ts": "0.23.1"
   },
   "resolutions": {
     "assemblyscript": "0.19.10"

--- a/examples/example-subgraph/yarn.lock
+++ b/examples/example-subgraph/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@graphprotocol/graph-ts@0.22.1":
-  version "0.22.1"
-  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-ts/-/graph-ts-0.22.1.tgz#3189b2495b33497280f617316cce68074d48e236"
-  integrity sha512-T5xrHN0tHJwd7ZnSTLhk5hAL3rCIp6rJ40kBCrETnv1mfK9hVyoojJK6VtBQXTbLsYtKe4SYjjD0cdOsAR9QiA==
+"@graphprotocol/graph-ts@0.23.1":
+  version "0.23.1"
+  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-ts/-/graph-ts-0.23.1.tgz#76e595d26ec5672f3778b1d3830e4640a57aec1b"
+  integrity sha512-pipofvN1LlwLOXrS7IWy8hSBFZzVyVHdLXDpQskl9nKqdbb3chelj4JoVEzCl7klvomDpP84ngLpW17fBh5vww==
   dependencies:
     assemblyscript "0.19.10"
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphprotocol/graph-cli",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "description": "CLI for building for and deploying to The Graph",
   "dependencies": {
     "assemblyscript": "0.19.10",

--- a/src/scaffold.js
+++ b/src/scaffold.js
@@ -49,7 +49,7 @@ const generatePackageJson = ({ subgraphName, node }) =>
       },
       dependencies: {
         '@graphprotocol/graph-cli': graphCliVersion,
-        '@graphprotocol/graph-ts': `0.22.1`,
+        '@graphprotocol/graph-ts': `0.23.1`,
       },
     }),
     { parser: 'json' },

--- a/src/scaffold.js
+++ b/src/scaffold.js
@@ -152,6 +152,14 @@ const generateSchema = ({ abi, indexEvents }) => {
   )
 }
 
+const tsConfig = prettier.format(
+  JSON.stringify({
+    extends: '@graphprotocol/graph-ts/types/tsconfig.base.json',
+    include: ['src'],
+  }),
+  { parser: 'json' },
+)
+
 // Mapping
 
 const generateTupleFieldAssignments = ({ keyPath, index, component }) => {
@@ -310,6 +318,7 @@ const generateScaffold = async (
     'package.json': packageJson,
     'subgraph.yaml': manifest,
     'schema.graphql': schema,
+    'tsconfig.json': tsConfig,
     src: { 'mapping.ts': mapping },
     abis: {
       [`${contractName}.json`]: prettier.format(JSON.stringify(abi.data), {


### PR DESCRIPTION
This PR:

- Bumps graph-ts's version
- Uses their `tsconfig.base.json` on `graph init` command
- Release a new patch on npm `0.23.1`

Also, it would be nice to merge [this one](https://github.com/graphprotocol/graph-cli/pull/770) first so that the CI finally can pass properly on release PRs 🙂 