### PR TITLE
Local Graph node debug tool using a remote GraphQL endpoint (per LimeChain)

### DIFF
--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -30,6 +30,7 @@ Options:
   -l  --version-label <label>   Version label used for the deployment
   -h, --help                    Show usage information
   -i, --ipfs <node>             Upload build results to an IPFS node (default: ${DEFAULT_IPFS_URL})
+      --debug-fork              ID of a remote subgraph whose store will be GraphQL queried
   -o, --output-dir <path>       Output directory for build results (default: build/)
       --skip-migrations         Skip subgraph migrations (default: false)
   -w, --watch                   Regenerate types when subgraph files change (default: false)
@@ -96,6 +97,7 @@ module.exports = {
       skipMigrations,
       w,
       watch,
+      debugFork,
     } = toolbox.parameters.options
 
     // Support both long and short option variants
@@ -189,6 +191,8 @@ module.exports = {
       return
     }
 
+    // TODO: validate that debugFork is a valid IPFS hash
+
     let protocol
     try {
       // Checks to make sure deploy doesn't run against
@@ -264,7 +268,7 @@ module.exports = {
       //       `Failed to deploy to Graph node ${requestUrl}`,
       client.request(
         'subgraph_deploy',
-        { name: subgraphName, ipfs_hash: ipfsHash, version_label: versionLabel },
+        { name: subgraphName, ipfs_hash: ipfsHash, version_label: versionLabel, debug_fork: debugFork },
         async (requestError, jsonRpcError, res) => {
           if (jsonRpcError) {
             spinner.fail(


### PR DESCRIPTION
Related to and dependant on https://github.com/graphprotocol/graph-node/pull/2995

Adds the `graph debug` command to enable easy debugging of subgraphs from the cli.

---
### Some points to discuss
Since there is a significant overlap between `graph debug` and `graph deploy`, should we abstract away some of the functionality in util functions and call them in both commands where appropriate?