### PR TITLE
codegen: Remove default values for primitive schema fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphprotocol/graph-cli",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "description": "CLI for building for and deploying to The Graph",
   "dependencies": {
     "assemblyscript": "0.19.10",


### PR DESCRIPTION
In the AssemblyScript update a new feature was added to the CLI.

Schemas with types such as:

```graphql
type Total @entity {
  id: ID!
  amount: BigInt
}
```

Started to have their setters called on the constructor with the default
value for the type, eg:

```typescript
export class Total extends Entity {
  constructor(id: string) {
    super();
    this.set("id", Value.fromString(id));

    this.set("amount", Value.fromBigInt(BigInt.zero()));
  }
  // ...
}
```

The problem is that these new set calls were being called with
primitives as well, that is a bug.

This commit fixes the issue by checking if the field is primitive to
avoid generating the wrong call.