### PR TITLE
graph-cli test command docker adjustments

### DIFF
--- a/src/commands/test.js
+++ b/src/commands/test.js
@@ -274,6 +274,7 @@ async function dockerfile(dockerfilePath, versionOpt, latestVersion) {
     process.exit(1)
   }
 
+  // Replaces the version placeholders
   await patching.update(dockerfilePath, data => {
     return data.replace('<MATCHSTICK_VERSION>', versionOpt || latestVersion)
   })

--- a/src/commands/test.js
+++ b/src/commands/test.js
@@ -224,7 +224,7 @@ async function runDocker(datasource, opts) {
       // run a container from that image.
       spawn(
         'docker',
-        ['build', '--no-cache', '-f', `${dockerDir}/Dockerfile`, '-t', 'matchstick', '.'],
+        ['build', '-f', `${dockerDir}/Dockerfile`, '-t', 'matchstick', '.'],
         { stdio: 'inherit' }
       ).on('close', code => {
         if (code === 0) {
@@ -243,6 +243,9 @@ async function runDocker(datasource, opts) {
 function dockerfile(versionOpt, latestVersion) {
   return `
   FROM ubuntu:20.04
+
+  ARG BUILDPLATFORM=linux/x86_64
+
   ENV ARGS=""
 
   # Install necessary packages
@@ -263,7 +266,7 @@ function dockerfile(versionOpt, latestVersion) {
 
   # Create a matchstick dir where the host will be copied
   RUN mkdir matchstick
-  WORKDIR matchstick
+  WORKDIR /matchstick
 
   # Copy host to /matchstick
   COPY ../ .


### PR DESCRIPTION
Issues:
https://github.com/LimeChain/matchstick/issues/275
https://github.com/LimeChain/matchstick/issues/283

What this PR does:

1. Matchstick offers the the option for users to define a custom libs or test folder. Until now the test folder could be declared in the `subgraph.yaml` with the `testsFolder` key, but adding this key was breaking `codegen` and `build` commands. And the libs folder was passed with the `-l` flag to the matchstick binary, which conflicts with `-l/--logs` flag in `graph-cli test`. So we decided to add a separate `matchstick.yaml` config. The `graph-cli test` command previously used the subgraph.yaml to check if `testsFolder` is declared and use it to store the created `Dockerfile` there if the `-d/--docker`   flag is used, and now it will look for `matchstick.yaml` instead

2. Changes to the docker option:
    - Now it fetches the [Dockerfile](https://github.com/LimeChain/demo-subgraph/blob/main/Dockerfile) template from the demo-subgraph repo. Using `glueguns's` `patching`, replaces the version placeholder with either the latest version or the one passed with the `-v/--version` flag by the user. This way the Dockerfile can be quickly updated, without the need to make a PR to the graph-cli or release new versions.
    - Also changes in which cases the Dockerfile is [re]created. Now it's when either it does not exist, a matchstick version is passed with `-v/--version flag` or the `-f/--force` flag is passed.
    - Removes the `--no-cache` flag from the `docker build` command