### PR TITLE
Graph test command: Fix Linux version

### DIFF
--- a/src/commands/test.js
+++ b/src/commands/test.js
@@ -127,12 +127,10 @@ async function getPlatform(logsOpt) {
   const release = os.release()
   const cpuCore = os.cpus()[0]
   const isM1 = cpuCore.model.includes("Apple M1")
-  const majorVersion = semver.major(release)
-  let linuxVersion = ""
-  if (type === 'Linux') linuxVersion = await getLinuxVersion()
+  const majorVersion = (type === 'Linux') ? await getLinuxVersion() : semver.major(release)
 
   if (logsOpt) {
-    print.info(`OS type: ${type}\nOS arch: ${arch}\nOS release: ${release}\nOS major version: ${type === 'Linux' ? linuxVersion : majorVersion}\nCPU model: ${cpuCore.model}`)
+    print.info(`OS type: ${type}\nOS arch: ${arch}\nOS release: ${release}\nOS major version: ${majorVersion}\nCPU model: ${cpuCore.model}`)
   }
 
   if (arch === 'x64' || (arch === 'arm64' && isM1)) {
@@ -146,12 +144,12 @@ async function getPlatform(logsOpt) {
       }
       return 'binary-macos-11'
     } else if (type === 'Linux') {
-      if (linuxVersion === '18.04') {
+      if (majorVersion === 18) {
         return 'binary-linux-18'
-      } else if (linuxVersion == '20.04') {
+      } else if (majorVersion == 20) {
         return 'binary-linux-20'
       } else {
-        throw new Error(`Unsupported Linux Version: ${linuxVersion}`)
+        throw new Error(`Unsupported Linux Version: ${majorVersion}`)
       }
     } else if (type === 'Windows_NT') {
       return 'binary-windows'
@@ -163,7 +161,8 @@ async function getPlatform(logsOpt) {
 
 async function getLinuxVersion() {
   let version = await system.run("grep '^VERSION_ID' /etc/os-release", {trim: true})
-  return version.replace(/[VERSION_ID=]|['"]+/g, '').trim()
+  version = version.replace(/[VERSION_ID=]|['"]+/g, '')
+  return parseInt(version)
 }
 
 async function runDocker(datasource, opts) {

--- a/src/commands/test.js
+++ b/src/commands/test.js
@@ -132,7 +132,7 @@ async function getPlatform(logsOpt) {
   const majorVersion = parseInt(linuxInfo.get('version'), 10) || semver.major(release)
 
   if (logsOpt) {
-    print.info(`OS: ${linuxDistro || type}\nOS arch: ${arch}\nOS release: ${release}\nOS major version: ${majorVersion}\nCPU model: ${cpuCore.model}`)
+    print.info(`OS type: ${linuxDistro || type}\nOS arch: ${arch}\nOS release: ${release}\nOS major version: ${majorVersion}\nCPU model: ${cpuCore.model}`)
   }
 
   if (arch === 'x64' || (arch === 'arm64' && isM1)) {

--- a/src/commands/test.js
+++ b/src/commands/test.js
@@ -168,7 +168,7 @@ async function getLinuxInfo() {
     infoArray.forEach((val) => {
       infoMap.set(val[0].toLowerCase(), val[1])
     });
-    print.info(infoMap)
+    
     return infoMap
   } catch (error) {
     print.error(`Error fetching the Linux version:\n ${error}`)

--- a/src/commands/test.js
+++ b/src/commands/test.js
@@ -127,12 +127,12 @@ async function getPlatform(logsOpt) {
   const cpuCore = os.cpus()[0]
   const isM1 = cpuCore.model.includes("Apple M1")
   const linuxInfo = type === 'Linux' ? await getLinuxInfo() : []
-  const linuxDestro = linuxInfo[0] || type
+  const linuxDistro = linuxInfo[0] || type
   const release = linuxInfo[1] || os.release()
   const majorVersion = parseInt(linuxInfo[1]) || semver.major(release)
 
   if (logsOpt) {
-    print.info(`OS: ${linuxDestro || type}\nOS arch: ${arch}\nOS release: ${release}\nOS major version: ${majorVersion}\nCPU model: ${cpuCore.model}`)
+    print.info(`OS: ${linuxDistro || type}\nOS arch: ${arch}\nOS release: ${release}\nOS major version: ${majorVersion}\nCPU model: ${cpuCore.model}`)
   }
 
   if (arch === 'x64' || (arch === 'arm64' && isM1)) {
@@ -161,7 +161,7 @@ async function getPlatform(logsOpt) {
 
 async function getLinuxInfo() {
   try {
-    let info = await system.run("cat /etc/*-release | egrep -e '(^VERSION|^NAME)='", {trim: true})
+    let info = await system.run("cat /etc/*-release | grep -E '(^VERSION|^NAME)='", {trim: true})
     return info.replace(/[VERSION=]|[NAME=]|['"]+/g, '').split('\n')
   } catch (error) {
     print.error(`Error fetching the Linux version:\n ${error}`)


### PR DESCRIPTION
What it does:

The `os` module can't determine the Linux distro and version correctly, so until now the `graph test` command always downloaded the linux-20 binary. Now if the OS type is Linux, it will grep the content of `/etc/*-release` and fetch the distro name and full version and use them to determine which linux binary to download, and will display better info when `-l` flag is passed.