### PR TITLE
deps: Use exact versions (lock) to avoid unwanted updates

### DIFF
--- a/examples/basic-event-handlers/package.json
+++ b/examples/basic-event-handlers/package.json
@@ -13,7 +13,7 @@
     "apollo-fetch": "^0.7.0"
   },
   "dependencies": {
-    "babel-polyfill": "^6.26.0",
+    "babel-polyfill": "6.26.0",
     "babel-register": "^6.26.0",
     "truffle": "^5.0.4",
     "truffle-hdwallet-provider": "^1.0.4"

--- a/examples/basic-event-handlers/package.json
+++ b/examples/basic-event-handlers/package.json
@@ -16,7 +16,7 @@
     "babel-polyfill": "6.26.0",
     "babel-register": "6.26.0",
     "truffle": "^5.0.4",
-    "truffle-hdwallet-provider": "^1.0.4"
+    "truffle-hdwallet-provider": "1.0.6"
   },
   "resolutions": {
     "assemblyscript": "0.19.10"

--- a/examples/basic-event-handlers/package.json
+++ b/examples/basic-event-handlers/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "babel-polyfill": "6.26.0",
     "babel-register": "6.26.0",
-    "truffle": "^5.0.4",
+    "truffle": "5.0.12",
     "truffle-hdwallet-provider": "1.0.6"
   },
   "resolutions": {

--- a/examples/basic-event-handlers/package.json
+++ b/examples/basic-event-handlers/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "babel-polyfill": "6.26.0",
-    "babel-register": "^6.26.0",
+    "babel-register": "6.26.0",
     "truffle": "^5.0.4",
     "truffle-hdwallet-provider": "^1.0.4"
   },

--- a/examples/basic-event-handlers/yarn.lock
+++ b/examples/basic-event-handlers/yarn.lock
@@ -112,9 +112,9 @@ babel-messages@^6.23.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-polyfill@^6.26.0:
+babel-polyfill@6.26.0:
   version "6.26.0"
-  resolved "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
+  resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
   integrity sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=
   dependencies:
     babel-runtime "^6.26.0"

--- a/examples/basic-event-handlers/yarn.lock
+++ b/examples/basic-event-handlers/yarn.lock
@@ -920,9 +920,9 @@ trim-right@^1.0.1:
   resolved "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
 
-truffle-hdwallet-provider@^1.0.4:
+truffle-hdwallet-provider@1.0.6:
   version "1.0.6"
-  resolved "https://registry.npmjs.org/truffle-hdwallet-provider/-/truffle-hdwallet-provider-1.0.6.tgz#7cda437c9a25bda6bbc5f4ed018e932254ecc867"
+  resolved "https://registry.yarnpkg.com/truffle-hdwallet-provider/-/truffle-hdwallet-provider-1.0.6.tgz#7cda437c9a25bda6bbc5f4ed018e932254ecc867"
   integrity sha512-cYTG0t9XouLLEBLMjkfHe3s2JO9wrFFVeXEgpW5Ay+8S56isf3LkrAUh0ws9bcYCJ0l7jho9xkaNnakeDqq//Q==
   dependencies:
     any-promise "^1.3.0"

--- a/examples/basic-event-handlers/yarn.lock
+++ b/examples/basic-event-handlers/yarn.lock
@@ -929,9 +929,9 @@ truffle-hdwallet-provider@1.0.6:
     bindings "^1.3.1"
     websocket "^1.0.28"
 
-truffle@^5.0.4:
+truffle@5.0.12:
   version "5.0.12"
-  resolved "https://registry.npmjs.org/truffle/-/truffle-5.0.12.tgz#05ab7d2561a3ee4fd5e026dcc4b91b8f3c6e3795"
+  resolved "https://registry.yarnpkg.com/truffle/-/truffle-5.0.12.tgz#05ab7d2561a3ee4fd5e026dcc4b91b8f3c6e3795"
   integrity sha512-dqnDmtTGNcnL29PHQwPE/CVmFFeGLuTFeb4TS3VY/vbASefu118IKXcadOWzkCPPwktv/njwylHSPhwoS00F2A==
   dependencies:
     app-module-path "^2.2.0"

--- a/examples/basic-event-handlers/yarn.lock
+++ b/examples/basic-event-handlers/yarn.lock
@@ -121,9 +121,9 @@ babel-polyfill@6.26.0:
     core-js "^2.5.0"
     regenerator-runtime "^0.10.5"
 
-babel-register@^6.26.0:
+babel-register@6.26.0, babel-register@^6.26.0:
   version "6.26.0"
-  resolved "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz#6ed021173e2fcb486d7acb45c6009a856f647071"
+  resolved "https://registry.yarnpkg.com/babel-register/-/babel-register-6.26.0.tgz#6ed021173e2fcb486d7acb45c6009a856f647071"
   integrity sha1-btAhFz4vy0htestFxgCahW9kcHE=
   dependencies:
     babel-core "^6.26.0"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "jest": "26.0.0",
     "spawn-command": "0.0.2-1",
     "strip-ansi": "6.0.0",
-    "tern": "^0.24.0"
+    "tern": "0.24.3"
   },
   "scripts": {
     "test": "jest --verbose",

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
   },
   "devDependencies": {
     "eslint": "6.8.0",
-    "jest": "^26.0.0",
-    "spawn-command": "^0.0.2-1",
-    "strip-ansi": "^6.0.0",
+    "jest": "26.0.0",
+    "spawn-command": "0.0.2-1",
+    "strip-ansi": "6.0.0",
     "tern": "^0.24.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "tmp-promise": "3.0.2",
     "web3-eth-abi": "1.7.0",
     "which": "2.0.2",
-    "yaml": "^1.5.1"
+    "yaml": "1.9.2"
   },
   "bin": {
     "graph": "bin/graph"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "fs-extra": "9.0.0",
     "glob": "7.1.6",
     "gluegun": "https://github.com/edgeandnode/gluegun#v4.3.1-pin-colors-dep",
-    "graphql": "^15.5.0",
+    "graphql": "15.5.0",
     "immutable": "^3.8.2",
     "ipfs-http-client": "^34.0.0",
     "jayson": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "assemblyscript": "0.19.10",
     "binary-install-raw": "0.0.13",
-    "chalk": "^3.0.0",
+    "chalk": "3.0.0",
     "chokidar": "^3.0.2",
     "debug": "^4.1.1",
     "docker-compose": "^0.23.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "docker-compose": "0.23.4",
     "dockerode": "2.5.8",
     "fs-extra": "9.0.0",
-    "glob": "^7.1.2",
+    "glob": "7.1.6",
     "gluegun": "https://github.com/edgeandnode/gluegun#v4.3.1-pin-colors-dep",
     "graphql": "^15.5.0",
     "immutable": "^3.8.2",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "chokidar": "3.5.1",
     "debug": "4.1.1",
     "docker-compose": "0.23.4",
-    "dockerode": "^2.5.8",
+    "dockerode": "2.5.8",
     "fs-extra": "^9.0.0",
     "glob": "^7.1.2",
     "gluegun": "https://github.com/edgeandnode/gluegun#v4.3.1-pin-colors-dep",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "debug": "4.1.1",
     "docker-compose": "0.23.4",
     "dockerode": "2.5.8",
-    "fs-extra": "^9.0.0",
+    "fs-extra": "9.0.0",
     "glob": "^7.1.2",
     "gluegun": "https://github.com/edgeandnode/gluegun#v4.3.1-pin-colors-dep",
     "graphql": "^15.5.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "binary-install-raw": "0.0.13",
     "chalk": "3.0.0",
     "chokidar": "3.5.1",
-    "debug": "^4.1.1",
+    "debug": "4.1.1",
     "docker-compose": "^0.23.2",
     "dockerode": "^2.5.8",
     "fs-extra": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "graph": "bin/graph"
   },
   "devDependencies": {
-    "eslint": "^6.0.1",
+    "eslint": "6.8.0",
     "jest": "^26.0.0",
     "spawn-command": "^0.0.2-1",
     "strip-ansi": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "chalk": "3.0.0",
     "chokidar": "3.5.1",
     "debug": "4.1.1",
-    "docker-compose": "^0.23.2",
+    "docker-compose": "0.23.4",
     "dockerode": "^2.5.8",
     "fs-extra": "^9.0.0",
     "glob": "^7.1.2",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "glob": "7.1.6",
     "gluegun": "https://github.com/edgeandnode/gluegun#v4.3.1-pin-colors-dep",
     "graphql": "15.5.0",
-    "immutable": "^3.8.2",
+    "immutable": "3.8.2",
     "ipfs-http-client": "^34.0.0",
     "jayson": "^3.0.2",
     "js-yaml": "^3.13.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "ipfs-http-client": "34.0.0",
     "jayson": "3.2.0",
     "js-yaml": "3.13.1",
-    "node-fetch": "^2.3.0",
+    "node-fetch": "2.6.0",
     "pkginfo": "^0.4.1",
     "prettier": "^1.13.5",
     "request": "^2.88.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "js-yaml": "3.13.1",
     "node-fetch": "2.6.0",
     "pkginfo": "0.4.1",
-    "prettier": "^1.13.5",
+    "prettier": "1.19.1",
     "request": "^2.88.0",
     "semver": "7.3.5",
     "sync-request": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "semver": "7.3.5",
     "sync-request": "6.1.0",
     "tmp-promise": "3.0.2",
-    "web3-eth-abi": "^1.7.0",
+    "web3-eth-abi": "1.7.0",
     "which": "2.0.2",
     "yaml": "^1.5.1"
   },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "node-fetch": "2.6.0",
     "pkginfo": "0.4.1",
     "prettier": "1.19.1",
-    "request": "^2.88.0",
+    "request": "2.88.2",
     "semver": "7.3.5",
     "sync-request": "^6.1.0",
     "tmp-promise": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "graphql": "15.5.0",
     "immutable": "3.8.2",
     "ipfs-http-client": "34.0.0",
-    "jayson": "^3.0.2",
+    "jayson": "3.2.0",
     "js-yaml": "^3.13.1",
     "node-fetch": "^2.3.0",
     "pkginfo": "^0.4.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "immutable": "3.8.2",
     "ipfs-http-client": "34.0.0",
     "jayson": "3.2.0",
-    "js-yaml": "^3.13.1",
+    "js-yaml": "3.13.1",
     "node-fetch": "^2.3.0",
     "pkginfo": "^0.4.1",
     "prettier": "^1.13.5",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "gluegun": "https://github.com/edgeandnode/gluegun#v4.3.1-pin-colors-dep",
     "graphql": "15.5.0",
     "immutable": "3.8.2",
-    "ipfs-http-client": "^34.0.0",
+    "ipfs-http-client": "34.0.0",
     "jayson": "^3.0.2",
     "js-yaml": "^3.13.1",
     "node-fetch": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "jayson": "3.2.0",
     "js-yaml": "3.13.1",
     "node-fetch": "2.6.0",
-    "pkginfo": "^0.4.1",
+    "pkginfo": "0.4.1",
     "prettier": "^1.13.5",
     "request": "^2.88.0",
     "semver": "7.3.5",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "request": "2.88.2",
     "semver": "7.3.5",
     "sync-request": "6.1.0",
-    "tmp-promise": "^3.0.2",
+    "tmp-promise": "3.0.2",
     "web3-eth-abi": "^1.7.0",
     "which": "2.0.2",
     "yaml": "^1.5.1"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "prettier": "1.19.1",
     "request": "2.88.2",
     "semver": "7.3.5",
-    "sync-request": "^6.1.0",
+    "sync-request": "6.1.0",
     "tmp-promise": "^3.0.2",
     "web3-eth-abi": "^1.7.0",
     "which": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "assemblyscript": "0.19.10",
     "binary-install-raw": "0.0.13",
     "chalk": "3.0.0",
-    "chokidar": "^3.0.2",
+    "chokidar": "3.5.1",
     "debug": "^4.1.1",
     "docker-compose": "^0.23.2",
     "dockerode": "^2.5.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5143,7 +5143,7 @@ request-promise-native@^1.0.8:
     stealthy-require "^1.1.1"
     tough-cookie "^2.3.3"
 
-request@^2.88.0, request@^2.88.2:
+request@2.88.2, request@^2.88.2:
   version "2.88.2"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
   integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2897,7 +2897,7 @@ ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-immutable@^3.8.2:
+immutable@3.8.2:
   version "3.8.2"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.2.tgz#c2439951455bb39913daf281376f1530e104adf3"
   integrity sha1-wkOZUUVbs5kT2vKBN28VMOEErfM=

--- a/yarn.lock
+++ b/yarn.lock
@@ -2978,7 +2978,7 @@ ipfs-block@~0.8.1:
     cids "~0.7.0"
     class-is "^1.1.0"
 
-ipfs-http-client@^34.0.0:
+ipfs-http-client@34.0.0:
   version "34.0.0"
   resolved "https://registry.yarnpkg.com/ipfs-http-client/-/ipfs-http-client-34.0.0.tgz#8804d06a11c22306332a8ffa0949b6f672a0c9c8"
   integrity sha512-4RCkk8ix4Dqn6sxqFVwuXWCZ1eLFPsVaj6Ijvu1fs9VYgxgVudsW9PWwarlr4mw1xUCmPWYyXnEbGgzBrfMy0Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2656,7 +2656,7 @@ glob-parent@^5.0.0, glob-parent@~5.1.0:
   dependencies:
     is-glob "^4.0.1"
 
-glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
+glob@7.1.6, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1824,6 +1824,13 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
+debug@4.1.1, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
+  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
+  dependencies:
+    ms "^2.1.1"
+
 debug@=3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
@@ -1842,13 +1849,6 @@ debug@^3.2.6:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
-  dependencies:
-    ms "^2.1.1"
-
-debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
-  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1946,7 +1946,7 @@ docker-modem@^1.0.8:
     readable-stream "~1.0.26-4"
     split-ca "^1.0.0"
 
-dockerode@^2.5.8:
+dockerode@2.5.8:
   version "2.5.8"
   resolved "https://registry.yarnpkg.com/dockerode/-/dockerode-2.5.8.tgz#1b661e36e1e4f860e25f56e0deabe9f87f1d0acc"
   integrity sha512-+7iOUYBeDTScmOmQqpUYQaE7F4vvIt6+gIZNHWhqAQEI887tiPFB9OvXI/HzQYqfUNvukMK+9myLW63oTJPZpw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -5799,7 +5799,7 @@ symbol-tree@^3.2.4:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
-sync-request@^6.1.0:
+sync-request@6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/sync-request/-/sync-request-6.1.0.tgz#e96217565b5e50bbffe179868ba75532fb597e68"
   integrity sha512-8fjNkrNlNCrVc/av+Jn+xxqfCjYaBoHqCsDz6mt030UMxJGr+GSfCV1dQt2gRtlL63+VPidwDVLr7V2OcTSdRw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2129,7 +2129,7 @@ eslint-visitor-keys@^1.1.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
   integrity sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==
 
-eslint@^6.0.1:
+eslint@6.8.0:
   version "6.8.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-6.8.0.tgz#62262d6729739f9275723824302fb227c8c93ffb"
   integrity sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2549,7 +2549,7 @@ fs-constants@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
   integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
 
-fs-extra@^9.0.0:
+fs-extra@9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.0.0.tgz#b6afc31036e247b2466dc99c29ae797d5d4580a3"
   integrity sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4861,7 +4861,7 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-prettier@^1.13.5:
+prettier@1.19.1:
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3777,7 +3777,7 @@ jest-worker@^26.0.0:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
-jest@^26.0.0:
+jest@26.0.0:
   version "26.0.0"
   resolved "https://registry.yarnpkg.com/jest/-/jest-26.0.0.tgz#848a960a95f0a0f3ef6144d0250198a6e4b7cb32"
   integrity sha512-OtoG+cpcP+UXx+pQ7rzoQ11Pfb5+OUkrsNn5YPc0GU2HeBktgTANonUZEgT6cCgUHX7jUiuDIusDNTL4iNcWGQ==
@@ -5568,7 +5568,7 @@ source-map@^0.7.3:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
-spawn-command@^0.0.2-1:
+spawn-command@0.0.2-1:
   version "0.0.2-1"
   resolved "https://registry.yarnpkg.com/spawn-command/-/spawn-command-0.0.2-1.tgz#62f5e9466981c1b796dc5929937e11c9c6921bd0"
   integrity sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A=
@@ -5724,6 +5724,13 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
+strip-ansi@6.0.0, strip-ansi@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.0.tgz#0b1571dd7669ccd4f3e06e14ef1eed26225ae532"
+  integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
+  dependencies:
+    ansi-regex "^5.0.0"
+
 strip-ansi@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
@@ -5737,13 +5744,6 @@ strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.0.tgz#0b1571dd7669ccd4f3e06e14ef1eed26225ae532"
-  integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
-  dependencies:
-    ansi-regex "^5.0.0"
 
 strip-bom@^4.0.0:
   version "4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3409,7 +3409,7 @@ iterable-ndjson@^1.1.0:
   dependencies:
     string_decoder "^1.2.0"
 
-jayson@^3.0.2:
+jayson@3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/jayson/-/jayson-3.2.0.tgz#df6d8139cd9f6ee2f56c8c2deaee448da7eccf1b"
   integrity sha512-DZQnwA57GcStw4soSYB2VntWXFfoWvmSarlaWePDYOWhjxT72PBM4atEBomaTaS1uqk3jFC9UO9AyWjlujo3xw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -6230,7 +6230,7 @@ wcwidth@^1.0.1:
   dependencies:
     defaults "^1.0.3"
 
-web3-eth-abi@^1.7.0:
+web3-eth-abi@1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/web3-eth-abi/-/web3-eth-abi-1.7.0.tgz#4fac9c7d9e5a62b57f8884b37371f515c766f3f4"
   integrity sha512-heqR0bWxgCJwjWIhq2sGyNj9bwun5+Xox/LdZKe+WMyTSy0cXDXEAgv3XKNkXC4JqdDt/ZlbTEx4TWak4TRMSg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1931,7 +1931,7 @@ diff-sequences@^26.0.0:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-26.0.0.tgz#0760059a5c287637b842bd7085311db7060e88a6"
   integrity sha512-JC/eHYEC3aSS0vZGjuoc4vHA0yAQTzhQQldXMeMF+JlxLGJlCO38Gma82NV9gk1jGFz8mDzUMeaKXvjRRdJ2dg==
 
-docker-compose@^0.23.2:
+docker-compose@0.23.4:
   version "0.23.4"
   resolved "https://registry.yarnpkg.com/docker-compose/-/docker-compose-0.23.4.tgz#43bcabcde55a6ba2873b52fe0ccd99dd8fdceba8"
   integrity sha512-yWdXby9uQ8o4syOfvoSJ9ZlTnLipvUmDn59uaYY5VGIUSUAfMPPGqE1DE3pOCnfSg9Tl9UOOFO0PCSAzuIHmuA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3796,7 +3796,7 @@ js-tokens@^4.0.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.13.1:
+js-yaml@3.13.1, js-yaml@^3.13.1:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1490,6 +1490,14 @@ caseless@^0.12.0, caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
+chalk@3.0.0, chalk@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
+  integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chalk@^2.0.0, chalk@^2.1.0, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -1498,14 +1506,6 @@ chalk@^2.0.0, chalk@^2.1.0, chalk@^2.4.2:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
-
-chalk@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
-  integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
 
 chalk@^4.0.0:
   version "4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1525,7 +1525,7 @@ chardet@^0.7.0:
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
-chokidar@^3.0.2:
+chokidar@3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.1.tgz#ee9ce7bbebd2b79f49f304799d5468e31e14e68a"
   integrity sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4841,7 +4841,7 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-pkginfo@^0.4.1:
+pkginfo@0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/pkginfo/-/pkginfo-0.4.1.tgz#b5418ef0439de5425fc4995042dced14fb2a84ff"
   integrity sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8=

--- a/yarn.lock
+++ b/yarn.lock
@@ -6377,7 +6377,7 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yaml@^1.5.1, yaml@^1.7.2:
+yaml@1.9.2, yaml@^1.7.2:
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.9.2.tgz#f0cfa865f003ab707663e4f04b3956957ea564ed"
   integrity sha512-HPT7cGGI0DuRcsO51qC1j9O16Dh1mZ2bnXwsi0jrSpsLz0WxOLSLXfkABVl6bZO629py3CU+OMJtpNHDLB97kg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4489,7 +4489,7 @@ node-addon-api@^2.0.0:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-2.0.2.tgz#432cfa82962ce494b132e9d72a15b29f71ff5d32"
   integrity sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==
 
-node-fetch@^2.3.0:
+node-fetch@2.6.0, node-fetch@^2.3.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
   integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -5884,7 +5884,7 @@ terminal-link@^2.0.0:
     ansi-escapes "^4.2.1"
     supports-hyperlinks "^2.0.0"
 
-tern@^0.24.0:
+tern@0.24.3:
   version "0.24.3"
   resolved "https://registry.yarnpkg.com/tern/-/tern-0.24.3.tgz#da0d9118490c15af4b1c94553d5f0fafc77a0977"
   integrity sha512-Z8uvtdWIlFn1GWy0HW5FhZ8VDryZwoJUdnjZU25C7/PBOltLIn1uv+WF3rVq6S1761YbsmbZYRP/l0ZJBCkvrw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2726,7 +2726,7 @@ graceful-fs@^4.2.4:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
 
-graphql@^15.5.0:
+graphql@15.5.0:
   version "15.5.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.5.0.tgz#39d19494dbe69d1ea719915b578bf920344a69d5"
   integrity sha512-OmaM7y0kaK31NKG31q4YbD2beNYa6jBBKtMFT6gLYJljHLJr42IqJ8KX08u3Li/0ifzTU5HjmoOOrwa5BRLeDA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -5945,7 +5945,7 @@ through2@^3.0.0, through2@^3.0.1:
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
 
-tmp-promise@^3.0.2:
+tmp-promise@3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/tmp-promise/-/tmp-promise-3.0.2.tgz#6e933782abff8b00c3119d63589ca1fb9caaa62a"
   integrity sha512-OyCLAKU1HzBjL6Ev3gxUeraJNlbNingmi8IrHHEsYH8LTmEuhvYfqvhn2F/je+mjf4N58UmZ96OMEy1JanSCpA==


### PR DESCRIPTION
This is being done to avoid unwanted updates from maintainers, eg: [`colors` incident](https://github.com/graphprotocol/graph-cli/pull/806#issue-1098110092).

Also I've separated each dependency update into a separate commit to:

- Ease review (so you can see what each version bump separately)
- Because I had issues when I tried to do all on one commit (one of the dependency resolutions went wrong because we needed multiple versions of it, so it was easier to separate it all to catch the bug)

