### PR TITLE
cli: Fix Aurora Etherscan API URLs

### DIFF
--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -283,6 +283,8 @@ const getEtherscanLikeAPIUrl = (network) => {
     case "bsc": return `https://api.bscscan.com/api`;
     case "matic": return `https://api.polygonscan.com/api`;
     case "mumbai": return `https://api-testnet.polygonscan.com/api`;
+    case "aurora": return `https://api.aurorascan.dev/api`;
+    case "aurora-testnet": return `https://api-testnet.aurorascan.dev/api`;
     default: return `https://api-${network}.etherscan.io/api`;
   }
 } 


### PR DESCRIPTION
Adds custom entries in `getEtherscanLikeAPIUrl` for `aurora` and `aurora-testnet`.

Aurora's Etherscan-like API endpoints are hosted under `.aurorascan.dev`. The CLI was previously unable to fetch ABI automatically from the Etherscan API due to using wrong URLs `https://api-aurora.etherscan.io/api/...`.