### PR TITLE
Release 0.27.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphprotocol/graph-cli",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "license": "(Apache-2.0 OR MIT)",
   "description": "CLI for building for and deploying to The Graph",
   "dependencies": {


### PR DESCRIPTION
- Add NEAR testnet network to `graph init` #804
- Add Aurora URLs for fetching ABIs #836
- Pin all `npm` dependencies because of `colors` incident #806 #835
- `matchstick` (the new `graph test`, docs)
    - Adds new `mockNew<EventName>` in `graph codegen` for each event in `subgraph.yaml` #816
    - Adds support for the new `matchstick.yaml` configuration file (change `testFolder` for example) #826
    - Few changes to how `docker` is used (eg: `--no-cache` option isn't passed anymore on `build`) #826
    - Fix issues for running with Linux and M1 #828 #830
- Refactor subgraph manifest validation to have better error messages now that we support more than one protocol (EVM-compatible and NEAR) #821
- Add license information in `package.json` #822