### PR TITLE
update kovan optimistic endpoint

### DIFF
--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -285,6 +285,7 @@ const getEtherscanLikeAPIUrl = (network) => {
     case "mumbai": return `https://api-testnet.polygonscan.com/api`;
     case "aurora": return `https://api.aurorascan.dev/api`;
     case "aurora-testnet": return `https://api-testnet.aurorascan.dev/api`;
+    case "optimism-kovan": return `https://api-kovan-optimistic.etherscan.io/api`;
     default: return `https://api-${network}.etherscan.io/api`;
   }
 } 


### PR DESCRIPTION
I Updated the wrong API endpoint for kovan optimistic, this really bugging me hard because i want to use optimistic network to deploy my smart contracts. And i need to test in the optimistic kovan network but the API endpoint to fetch the ABI is wrong lol