### PR TITLE
codegen: Bump minimum 'graph-ts' version required

### DIFF
--- a/src/commands/codegen.js
+++ b/src/commands/codegen.js
@@ -71,7 +71,7 @@ module.exports = {
       // because that would mean the CLI would generate code to
       // the wrong AssemblyScript version.
       await assertManifestApiVersion(manifest, '0.0.5')
-      await assertGraphTsVersion(path.dirname(manifest), '0.22.0')
+      await assertGraphTsVersion(path.dirname(manifest), '0.25.0')
 
       const dataSourcesAndTemplates = await DataSourcesExtractor.fromFilePath(manifest)
 

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -200,7 +200,7 @@ module.exports = {
       // because that would mean the CLI would try to compile code
       // using the wrong AssemblyScript compiler.
       await assertManifestApiVersion(manifest, '0.0.5')
-      await assertGraphTsVersion(path.dirname(manifest), '0.22.0')
+      await assertGraphTsVersion(path.dirname(manifest), '0.25.0')
 
       const dataSourcesAndTemplates = await DataSourcesExtractor.fromFilePath(manifest)
 


### PR DESCRIPTION
This is required after https://github.com/graphprotocol/graph-ts/pull/253, otherwise subgraph developers will experience errors like these:

```
ERROR TS2339: Property 'displayData' does not exist on type '~lib/@graphprotocol/graph-ts/common/value/Value'. Entities of type [removed contract name] must have an ID of type String but the id '${id.displayData()}' is of type ${id.displayKind()} ~~~ in generated/schema.ts(1036,102) ERROR TS2339: Property 'displayKind' does not exist on type '~lib/@graphprotocol/graph-ts/common/value/Value'. Entities of type [removed contract name] must have an ID of type String but the id '${id.displayData()}' is of type ${id.displayKind()} ~~~ in generated/schema.ts(1036,134)
```

Methods like `displayData` are available only in `graph-ts` versions greater than or equal to `0.26.0`