### PR TITLE
Allow event handlers to require transaction receipts

### DIFF
--- a/examples/basic-event-handlers/package.json
+++ b/examples/basic-event-handlers/package.json
@@ -9,7 +9,7 @@
     "deploy-test": "../../bin/graph deploy test/basic-event-handlers --version-label v0.0.1 --ipfs http://localhost:15001 --node http://127.0.0.1:18020"
   },
   "devDependencies": {
-    "@graphprotocol/graph-ts": "0.27.0",
+    "@graphprotocol/graph-ts": "0.27.0-alpha.0",
     "apollo-fetch": "^0.7.0"
   },
   "dependencies": {

--- a/examples/basic-event-handlers/package.json
+++ b/examples/basic-event-handlers/package.json
@@ -9,7 +9,7 @@
     "deploy-test": "../../bin/graph deploy test/basic-event-handlers --version-label v0.0.1 --ipfs http://localhost:15001 --node http://127.0.0.1:18020"
   },
   "devDependencies": {
-    "@graphprotocol/graph-ts": "0.26.0",
+    "@graphprotocol/graph-ts": "0.27.0",
     "apollo-fetch": "^0.7.0"
   },
   "dependencies": {

--- a/examples/basic-event-handlers/yarn.lock
+++ b/examples/basic-event-handlers/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@graphprotocol/graph-ts@0.26.0":
-  version "0.26.0"
-  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-ts/-/graph-ts-0.26.0.tgz#576f995531eebaca4374901aeaff499219e382e8"
-  integrity sha512-GW/emOJl+35MXgmIxTnUK7dJtPCaB9u5aAwoLVqJ8swogC794O92UrXMVrAJsherUriu+yI9bLMGmNPOIi60jw==
+"@graphprotocol/graph-ts@0.27.0-alpha.0":
+  version "0.27.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-ts/-/graph-ts-0.27.0-alpha.0.tgz#1d50fc3fe7e574b09f206d60a5d9889d5e95beba"
+  integrity sha512-aS1VQUgj3dSvodDMJSBoyYfHjBA8UsUc/JUIrz+R5DjpxFx7wq5yzzB6GGlwEhuBV93UEh4UdmRDPWT/SKD5sg==
   dependencies:
     assemblyscript "0.19.10"
 

--- a/examples/example-subgraph/package.json
+++ b/examples/example-subgraph/package.json
@@ -7,7 +7,7 @@
     "build-wast": "../../bin/graph build -t wast subgraph.yaml"
   },
   "devDependencies": {
-    "@graphprotocol/graph-ts": "0.26.0"
+    "@graphprotocol/graph-ts": "0.27.0"
   },
   "resolutions": {
     "assemblyscript": "0.19.10"

--- a/examples/example-subgraph/package.json
+++ b/examples/example-subgraph/package.json
@@ -7,7 +7,7 @@
     "build-wast": "../../bin/graph build -t wast subgraph.yaml"
   },
   "devDependencies": {
-    "@graphprotocol/graph-ts": "0.27.0"
+    "@graphprotocol/graph-ts": "0.27.0-alpha.0"
   },
   "resolutions": {
     "assemblyscript": "0.19.10"

--- a/examples/example-subgraph/yarn.lock
+++ b/examples/example-subgraph/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@graphprotocol/graph-ts@0.26.0":
-  version "0.26.0"
-  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-ts/-/graph-ts-0.26.0.tgz#576f995531eebaca4374901aeaff499219e382e8"
-  integrity sha512-GW/emOJl+35MXgmIxTnUK7dJtPCaB9u5aAwoLVqJ8swogC794O92UrXMVrAJsherUriu+yI9bLMGmNPOIi60jw==
+"@graphprotocol/graph-ts@0.27.0-alpha.0":
+  version "0.27.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-ts/-/graph-ts-0.27.0-alpha.0.tgz#1d50fc3fe7e574b09f206d60a5d9889d5e95beba"
+  integrity sha512-aS1VQUgj3dSvodDMJSBoyYfHjBA8UsUc/JUIrz+R5DjpxFx7wq5yzzB6GGlwEhuBV93UEh4UdmRDPWT/SKD5sg==
   dependencies:
     assemblyscript "0.19.10"
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphprotocol/graph-cli",
-  "version": "0.29.0",
+  "version": "0.30.0-alpha.0",
   "license": "(Apache-2.0 OR MIT)",
   "description": "CLI for building for and deploying to The Graph",
   "dependencies": {

--- a/src/migrations.js
+++ b/src/migrations.js
@@ -5,7 +5,9 @@ const MIGRATIONS = [
   require('./migrations/mapping_api_version_0_0_2'),
   require('./migrations/mapping_api_version_0_0_3'),
   require('./migrations/mapping_api_version_0_0_4'),
+  require('./migrations/mapping_api_version_0_0_5'),
   require('./migrations/spec_version_0_0_2'),
+  require('./migrations/spec_version_0_0_4'),
 ]
 
 const applyMigrations = async options =>

--- a/src/migrations/mapping_api_version_0_0_5.js
+++ b/src/migrations/mapping_api_version_0_0_5.js
@@ -21,7 +21,7 @@ module.exports = {
 
     let manifest = loadManifest(manifestFile)
     return (
-      // Only migrate if the graph-ts version is >= 0.23.0...
+      // Only migrate if the graph-ts version is >= 0.24.0...
       // Coerce needed because we may be dealing with an alpha version
       // and in the `semver` library this would not return true on equality.
       semver.gte(semver.coerce(graphTsVersion), '0.24.0') &&

--- a/src/migrations/mapping_api_version_0_0_6.js
+++ b/src/migrations/mapping_api_version_0_0_6.js
@@ -21,7 +21,7 @@ module.exports = {
 
     let manifest = loadManifest(manifestFile)
     return (
-      // Only migrate if the graph-ts version is >= 0.24.0...
+      // Only migrate if the graph-ts version is >= 0.27.0...
       // Coerce needed because we may be dealing with an alpha version
       // and in the `semver` library this would not return true on equality.
       semver.gte(semver.coerce(graphTsVersion), '0.27.0') &&

--- a/src/migrations/mapping_api_version_0_0_6.js
+++ b/src/migrations/mapping_api_version_0_0_6.js
@@ -1,0 +1,74 @@
+const fs = require('fs-extra')
+const semver = require('semver')
+const toolbox = require('gluegun/toolbox')
+const yaml = require('js-yaml')
+const { loadManifest } = require('./util/load-manifest')
+const { getGraphTsVersion } = require('./util/versions')
+
+// If any of the manifest apiVersions are 0.0.6, replace them with 0.0.7
+module.exports = {
+  name: 'Bump mapping apiVersion from 0.0.6 to 0.0.7',
+  predicate: async ({ sourceDir, manifestFile }) => {
+    // Obtain the graph-ts version, if possible
+    let graphTsVersion
+    try {
+      graphTsVersion = await getGraphTsVersion(sourceDir)
+    } catch (_) {
+      // If we cannot obtain the version, return a hint that the graph-ts
+      // hasn't been installed yet
+      return 'graph-ts dependency not installed yet'
+    }
+
+    let manifest = loadManifest(manifestFile)
+    return (
+      // Only migrate if the graph-ts version is >= 0.24.0...
+      // Coerce needed because we may be dealing with an alpha version
+      // and in the `semver` library this would not return true on equality.
+      semver.gte(semver.coerce(graphTsVersion), '0.27.0') &&
+      // ...and we have a manifest with mapping > apiVersion = 0.0.6
+      manifest &&
+      typeof manifest === 'object' &&
+      Array.isArray(manifest.dataSources) &&
+      (manifest.dataSources.reduce(
+        (hasOldMappings, dataSource) =>
+          hasOldMappings ||
+          (typeof dataSource === 'object' &&
+            dataSource.mapping &&
+            typeof dataSource.mapping === 'object' &&
+            dataSource.mapping.apiVersion === '0.0.6'),
+        false,
+      ) ||
+        (Array.isArray(manifest.templates) &&
+          manifest.templates.reduce(
+            (hasOldMappings, template) =>
+              hasOldMappings ||
+              (typeof template === 'object' &&
+                template.mapping &&
+                typeof template.mapping === 'object' &&
+                template.mapping.apiVersion === '0.0.6'),
+            false,
+          )))
+    )
+  },
+  apply: async ({ manifestFile }) => {
+    // Make sure we catch all variants; we could load the manifest
+    // and replace the values in the data structures here; unfortunately
+    // writing that back to the file messes with the formatting more than
+    // we'd like; that's why for now, we use a simple patching approach
+    await toolbox.patching.replace(
+      manifestFile,
+      new RegExp('apiVersion: 0.0.6', 'g'),
+      'apiVersion: 0.0.7',
+    )
+    await toolbox.patching.replace(
+      manifestFile,
+      new RegExp("apiVersion: '0.0.6'", 'g'),
+      "apiVersion: '0.0.7'",
+    )
+    await toolbox.patching.replace(
+      manifestFile,
+      new RegExp('apiVersion: "0.0.6"', 'g'),
+      'apiVersion: "0.0.7"',
+    )
+  },
+}

--- a/src/migrations/spec_version_0_0_4.js
+++ b/src/migrations/spec_version_0_0_4.js
@@ -1,0 +1,25 @@
+const fs = require('fs-extra')
+const toolbox = require('gluegun/toolbox')
+const yaml = require('js-yaml')
+const { loadManifest } = require('./util/load-manifest')
+
+// Spec version 0.0.5 let event handlers require transaction receipt
+// data to be accessed in the runtime.
+module.exports = {
+  name: 'Bump manifest specVersion from 0.0.4 to 0.0.5',
+  predicate: async ({ sourceDir, manifestFile }) => {
+    let manifest = await loadManifest(manifestFile)
+    return (
+      manifest &&
+      typeof manifest === 'object' &&
+      manifest.specVersion &&
+      manifest.specVersion === '0.0.4'
+    )
+  },
+  apply: async ({ manifestFile }) => {
+    await toolbox.patching.patch(manifestFile, {
+      insert: 'specVersion: 0.0.5',
+      replace: new RegExp(`specVersion: ['"]?0.0.4['"]?`),
+    })
+  },
+}

--- a/src/protocols/ethereum/manifest.graphql
+++ b/src/protocols/ethereum/manifest.graphql
@@ -7,6 +7,7 @@
 scalar String
 scalar File
 scalar BigInt
+scalar Boolean
 
 type SubgraphManifest {
   specVersion: String!
@@ -72,6 +73,7 @@ type ContractEventHandler {
   event: String!
   topic0: String
   handler: String!
+  receipt: Boolean
 }
 
 type Graft {

--- a/src/scaffold/index.js
+++ b/src/scaffold/index.js
@@ -50,7 +50,7 @@ module.exports = class Scaffold {
         },
         dependencies: {
           '@graphprotocol/graph-cli': GRAPH_CLI_VERSION,
-          '@graphprotocol/graph-ts': `0.27.0`,
+          '@graphprotocol/graph-ts': `0.27.0-alpha.0`,
         },
       }),
       { parser: 'json' },

--- a/src/scaffold/index.js
+++ b/src/scaffold/index.js
@@ -50,7 +50,7 @@ module.exports = class Scaffold {
         },
         dependencies: {
           '@graphprotocol/graph-cli': GRAPH_CLI_VERSION,
-          '@graphprotocol/graph-ts': `0.26.0`,
+          '@graphprotocol/graph-ts': `0.27.0`,
         },
       }),
       { parser: 'json' },

--- a/src/validation/manifest.js
+++ b/src/validation/manifest.js
@@ -204,6 +204,18 @@ const validators = immutable.fromJS({
             message: `Expected filename, found ${typeName(value)}:\n${value}`,
           },
         ]),
+
+  Boolean: (value, ctx) =>
+    typeof value === 'boolean'
+      ? List()
+      : immutable.fromJS([
+          {
+            path: ctx.get('path'),
+            message: `Expected true or false, found ${typeName(value)}:\n${toYAML(
+              value,
+            )}`,
+          },
+        ]),
 })
 
 const validateValue = (value, ctx) => {


### PR DESCRIPTION
Introduces `apiVersion` `0.0.7`, which allows event handlers to require transaction receipts to be available inside mappings,

TODO:
- [x] Migrations
- [ ] Update lockfiles as soon as `graph-ts` new version is available in external registries.
- [ ] NPM release

---
This PR is depends on
- https://github.com/graphprotocol/graph-cli/pull/724
- https://github.com/graphprotocol/graph-ts/pull/260

and is a dependency of:
- https://github.com/graphprotocol/graph-node/pull/3373
