### PR TITLE
Include migration to apiVersion 0.0.7

### DIFF
--- a/src/migrations.js
+++ b/src/migrations.js
@@ -6,6 +6,7 @@ const MIGRATIONS = [
   require('./migrations/mapping_api_version_0_0_3'),
   require('./migrations/mapping_api_version_0_0_4'),
   require('./migrations/mapping_api_version_0_0_5'),
+  require('./migrations/mapping_api_version_0_0_6'),
   require('./migrations/spec_version_0_0_2'),
   require('./migrations/spec_version_0_0_4'),
 ]


### PR DESCRIPTION
This should've been included in #860.
Without this, we would ignore the migration to `apiVersion 0.0.7`