### PR TITLE
init.js: Add EtherscanLikeAPIUrl for AVAX

### DIFF
--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -288,6 +288,7 @@ const getEtherscanLikeAPIUrl = (network) => {
     case "aurora": return `https://api.aurorascan.dev/api`;
     case "aurora-testnet": return `https://api-testnet.aurorascan.dev/api`;
     case "optimism-kovan": return `https://api-kovan-optimistic.etherscan.io/api`;
+    case "avalanche": return `https://api.snowtrace.io/api`;
     default: return `https://api-${network}.etherscan.io/api`;
   }
 }


### PR DESCRIPTION
This commit adds snowtrace.io as the api target for the avalanche network