### PR TITLE
Bump `graph-ts`

### DIFF
--- a/examples/basic-event-handlers/package.json
+++ b/examples/basic-event-handlers/package.json
@@ -9,7 +9,7 @@
     "deploy-test": "../../bin/graph deploy test/basic-event-handlers --version-label v0.0.1 --ipfs http://localhost:15001 --node http://127.0.0.1:18020"
   },
   "devDependencies": {
-    "@graphprotocol/graph-ts": "0.27.0-alpha.0",
+    "@graphprotocol/graph-ts": "0.27.0-alpha.1",
     "apollo-fetch": "^0.7.0"
   },
   "dependencies": {

--- a/examples/basic-event-handlers/yarn.lock
+++ b/examples/basic-event-handlers/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@graphprotocol/graph-ts@0.27.0-alpha.0":
-  version "0.27.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-ts/-/graph-ts-0.27.0-alpha.0.tgz#1d50fc3fe7e574b09f206d60a5d9889d5e95beba"
-  integrity sha512-aS1VQUgj3dSvodDMJSBoyYfHjBA8UsUc/JUIrz+R5DjpxFx7wq5yzzB6GGlwEhuBV93UEh4UdmRDPWT/SKD5sg==
+"@graphprotocol/graph-ts@0.27.0-alpha.1":
+  version "0.27.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-ts/-/graph-ts-0.27.0-alpha.1.tgz#1ea72417944820959c6edb24e217b4e37099deaa"
+  integrity sha512-zQzbGZnP9SPo3K0y+DqPY0j80KSDAQHzGoPcR3wN8rz9++UF/vTGqWZV4f9RGY+n29SQ4KLzFzDiQaL67hxBsA==
   dependencies:
     assemblyscript "0.19.10"
 

--- a/examples/example-subgraph/package.json
+++ b/examples/example-subgraph/package.json
@@ -7,7 +7,7 @@
     "build-wast": "../../bin/graph build -t wast subgraph.yaml"
   },
   "devDependencies": {
-    "@graphprotocol/graph-ts": "0.27.0-alpha.0"
+    "@graphprotocol/graph-ts": "0.27.0-alpha.1"
   },
   "resolutions": {
     "assemblyscript": "0.19.10"

--- a/examples/example-subgraph/yarn.lock
+++ b/examples/example-subgraph/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@graphprotocol/graph-ts@0.27.0-alpha.0":
-  version "0.27.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-ts/-/graph-ts-0.27.0-alpha.0.tgz#1d50fc3fe7e574b09f206d60a5d9889d5e95beba"
-  integrity sha512-aS1VQUgj3dSvodDMJSBoyYfHjBA8UsUc/JUIrz+R5DjpxFx7wq5yzzB6GGlwEhuBV93UEh4UdmRDPWT/SKD5sg==
+"@graphprotocol/graph-ts@0.27.0-alpha.1":
+  version "0.27.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-ts/-/graph-ts-0.27.0-alpha.1.tgz#1ea72417944820959c6edb24e217b4e37099deaa"
+  integrity sha512-zQzbGZnP9SPo3K0y+DqPY0j80KSDAQHzGoPcR3wN8rz9++UF/vTGqWZV4f9RGY+n29SQ4KLzFzDiQaL67hxBsA==
   dependencies:
     assemblyscript "0.19.10"
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphprotocol/graph-cli",
-  "version": "0.30.0-alpha.0",
+  "version": "0.30.0-alpha.1",
   "license": "(Apache-2.0 OR MIT)",
   "description": "CLI for building for and deploying to The Graph",
   "dependencies": {

--- a/src/scaffold/index.js
+++ b/src/scaffold/index.js
@@ -50,7 +50,7 @@ module.exports = class Scaffold {
         },
         dependencies: {
           '@graphprotocol/graph-cli': GRAPH_CLI_VERSION,
-          '@graphprotocol/graph-ts': `0.27.0-alpha.0`,
+          '@graphprotocol/graph-ts': `0.27.0-alpha.1`,
         },
       }),
       { parser: 'json' },


### PR DESCRIPTION
Update `graph-ts` to its latest version to account for https://github.com/graphprotocol/graph-ts/pull/271.

This also bumps `graph-cli` pre-release alpha version.