### PR TITLE
Fixing optimism etherscan base url

### DIFF
--- a/src/command-helpers/abi.js
+++ b/src/command-helpers/abi.js
@@ -59,6 +59,7 @@ const getEtherscanLikeAPIUrl = (network) => {
     case "aurora": return `https://api.aurorascan.dev/api`
     case "aurora-testnet": return `https://api-testnet.aurorascan.dev/api`
     case "optimism-kovan": return `https://api-kovan-optimistic.etherscan.io/api`
+    case "optimism": return `https://api-optimistic.etherscan.io/api`
     default: return `https://api-${network}.etherscan.io/api`
   }
 }


### PR DESCRIPTION
Creating an Optimism subgraph I realised that the cli failed to get the token abi.

### Wrong URL (Current)
`https://api-optimism.etherscan.io/api?module=contract&action=getabi&address=`

### Correct API URL
`https://api-optimistic.etherscan.io/api?module=contract&action=getabi&address=`

I tried it locally and it works fine now :)