### PR TITLE
fix: basic auth

### DIFF
--- a/src/command-helpers/jsonrpc.js
+++ b/src/command-helpers/jsonrpc.js
@@ -3,10 +3,14 @@ const toolbox = require('gluegun/toolbox')
 
 const createJsonRpcClient = url => {
   let params = {
-    auth: url.auth,
     host: url.hostname,
     port: url.port,
     path: url.pathname,
+  }
+
+  // username may be empty
+  if (url.password) {
+    params.auth = `${url.username}:${url.password}`
   }
 
   if (url.protocol === 'https:') {
@@ -15,10 +19,10 @@ const createJsonRpcClient = url => {
     return jayson.Client.http(params)
   } else {
     toolbox.print.error(
-      `Unsupported protocol: ${url.protocol.substring(0, url.protocol.length - 1)}`
+      `Unsupported protocol: ${url.protocol.substring(0, url.protocol.length - 1)}`,
     )
     toolbox.print.error(
-      'The Graph Node URL must be of the following format: http(s)://host[:port]/[path]'
+      'The Graph Node URL must be of the following format: http(s)://host[:port]/[path]',
     )
     return null
   }

--- a/src/command-helpers/jsonrpc.js
+++ b/src/command-helpers/jsonrpc.js
@@ -19,10 +19,10 @@ const createJsonRpcClient = url => {
     return jayson.Client.http(params)
   } else {
     toolbox.print.error(
-      `Unsupported protocol: ${url.protocol.substring(0, url.protocol.length - 1)}`,
+      `Unsupported protocol: ${url.protocol.substring(0, url.protocol.length - 1)}`
     )
     toolbox.print.error(
-      'The Graph Node URL must be of the following format: http(s)://host[:port]/[path]',
+      'The Graph Node URL must be of the following format: http(s)://host[:port]/[path]'
     )
     return null
   }


### PR DESCRIPTION
There is no auth field in URL.

```js
new URL('https://:password@example.com/path');
URL {
  href: 'https://:password@example.com/path',
  origin: 'https://example.com',
  protocol: 'https:',
  username: '',
  password: 'password',
  host: 'example.com',
  hostname: 'example.com',
  port: '',
  pathname: '/path',
  search: '',
  searchParams: URLSearchParams {},
  hash: ''
}
```