### PR TITLE
Replace `Tuple` with `ethereum.Tuple` in AssemblyScript -> Ethereum conversions table

### DIFF
--- a/src/codegen/types/conversions.js
+++ b/src/codegen/types/conversions.js
@@ -143,9 +143,9 @@ const ASSEMBLYSCRIPT_TO_ETHEREUM_VALUE = [
     /^string\[([0-9]+)?\]$/,
     code => `ethereum.Value.fromStringArray(${code})`,
   ],
-  ['Tuple', 'tuple', code => `ethereum.Value.fromTuple(${code})`],
+  ['ethereum.Tuple', 'tuple', code => `ethereum.Value.fromTuple(${code})`],
   [
-    'Array<Tuple>',
+    'Array<ethereum.Tuple>',
     /^tuple\[([0-9]+)?\]$/,
     code => `ethereum.Value.fromTupleArray(${code})`,
   ],


### PR DESCRIPTION
I believe at some point the `Tuple` struct name in the `AssemblyScript -> ethereum.Value` conversions table have not been updated and are left as `Tuple` instead of `ethereum.Tuple` 