### PR TITLE
Ensure contract actually has events when generating example tests

### DIFF
--- a/src/command-helpers/scaffold.js
+++ b/src/command-helpers/scaffold.js
@@ -128,8 +128,11 @@ const writeMapping = async (abi, protocol, contractName, entities) => {
   })
 }
 
-const writeTestsFiles = async (abi, contractName) => {
-  const events = abiEvents(abi).toJS()
+const writeTestsFiles = async (abi, protocol, contractName) => {
+  const hasEvents = protocol.hasEvents()
+  const events = hasEvents
+    ? abiEvents(abi).toJS()
+    : []
 
   if(events.length > 0) {
     // If a contract is added to a subgraph that has no tests folder

--- a/src/command-helpers/scaffold.js
+++ b/src/command-helpers/scaffold.js
@@ -129,16 +129,19 @@ const writeMapping = async (abi, protocol, contractName, entities) => {
 }
 
 const writeTestsFiles = async (abi, contractName) => {
-  // If a contract is added to a subgraph that has no tests folder
-  await fs.ensureDir('./tests/')
-
   const events = abiEvents(abi).toJS()
-  const testsFiles = generateTestsFiles(contractName, events, true)
 
-  for (const [fileName, content] of Object.entries(testsFiles)) {
-    await fs.writeFile(`./tests/${fileName}`, content, {
-      encoding: 'utf-8',
-    })
+  if(events.length > 0) {
+    // If a contract is added to a subgraph that has no tests folder
+    await fs.ensureDir('./tests/')
+
+    const testsFiles = generateTestsFiles(contractName, events, true)
+
+    for (const [fileName, content] of Object.entries(testsFiles)) {
+      await fs.writeFile(`./tests/${fileName}`, content, {
+        encoding: 'utf-8',
+      })
+    }
   }
 }
 

--- a/src/commands/add.js
+++ b/src/commands/add.js
@@ -102,10 +102,7 @@ module.exports = {
     await writeABI(ethabi, contractName)
     await writeSchema(ethabi, protocol, result.getIn(['schema', 'file']), collisionEntities)
     await writeMapping(ethabi, protocol, contractName, collisionEntities)
-
-    if (protocol.hasEvents()) {
-      await writeTestsFiles(ethabi, contractName)
-    }
+    await writeTestsFiles(ethabi, protocol, contractName)
 
     let dataSources = result.get('dataSources')
     let dataSource = await generateDataSource(protocol,

--- a/src/scaffold/index.js
+++ b/src/scaffold/index.js
@@ -143,8 +143,13 @@ dataSources:
   }
 
   generateTests() {
-    return this.protocol.hasEvents()
-      ?  generateTestsFiles(this.contractName, abiEvents(this.abi).toJS(), this.indexEvents)
+    const hasEvents = this.protocol.hasEvents()
+    const events = hasEvents
+      ? abiEvents(this.abi).toJS()
+      : []
+
+    return events.length > 0
+      ?  generateTestsFiles(this.contractName, events, this.indexEvents)
       : undefined
   }
 

--- a/src/scaffold/index.js
+++ b/src/scaffold/index.js
@@ -55,9 +55,7 @@ module.exports = class Scaffold {
           '@graphprotocol/graph-cli': GRAPH_CLI_VERSION,
           '@graphprotocol/graph-ts': `0.27.0`,
         },
-        devDependencies: {
-          'matchstick-as': `0.5.0`,
-        },
+        devDependencies: this.protocol.hasEvents() ? { 'matchstick-as': `0.5.0`} : undefined,
       }),
       { parser: 'json' },
     )


### PR DESCRIPTION
Currently the example test generation will break if `abiEvents(abi).toJS()` returns an empty array. This PR fixes that case.

Side note, `codegen` will also break if the contract abi has no events. The manifest scaffold loops through the list of events returned by `abiEvents(abi).toJS()`. If it's an empty array the `entities` and `eventHandlers` keys will have empty value, which will break `codegen`. The `entities` can be fixed with adding a check and setting `ExampleEntity` if the events array is empty. For the `eventHandlers` the case is not that easy, because you can't set a random event there, as `codegen` will check if that event exists in the contract ABI and will fail if not. If the whole `eventHandlers` key is omitted ` codegen` will again fail because it requires one of eventHandlers, callHandlers or blockHandlers to be declared in the manifest file. Maybe the best solution in this case will be to skip `codegen` at all.