### PR TITLE
Best practices for subgraph initialisation

### DIFF
--- a/examples/basic-event-handlers/build/subgraph.yaml
+++ b/examples/basic-event-handlers/build/subgraph.yaml
@@ -1,4 +1,4 @@
-specVersion: 0.0.2
+specVersion: 0.0.5
 description: Gravatar for Ethereum
 repository: https://github.com/graphprotocol/example-subgraph
 schema:
@@ -8,11 +8,11 @@ dataSources:
     name: Gravity
     network: test
     source:
-      address: "0xCfEB869F69431e42cdB54A4F4f105C19C080A601"
+      address: '0xCfEB869F69431e42cdB54A4F4f105C19C080A601'
       abi: Gravity
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.5
+      apiVersion: 0.0.7
       language: wasm/assemblyscript
       entities:
         - Gravatar

--- a/examples/basic-event-handlers/subgraph.yaml
+++ b/examples/basic-event-handlers/subgraph.yaml
@@ -1,4 +1,4 @@
-specVersion: 0.0.2
+specVersion: 0.0.5
 description: Gravatar for Ethereum
 repository: https://github.com/graphprotocol/example-subgraph
 schema:
@@ -12,7 +12,7 @@ dataSources:
       abi: Gravity
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.5
+      apiVersion: 0.0.7
       language: wasm/assemblyscript
       entities:
         - Gravatar

--- a/examples/example-subgraph/dist/subgraph.yaml
+++ b/examples/example-subgraph/dist/subgraph.yaml
@@ -1,4 +1,4 @@
-specVersion: 0.0.1
+specVersion: 0.0.5
 description: example of a subgraph
 repository: 'https://github.com/graphprotocol/graph-cli.git'
 schema:
@@ -12,7 +12,7 @@ dataSources:
       abi: ExampleContract
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.5
+      apiVersion: 0.0.7
       language: wasm/assemblyscript
       file: ExampleSubgraph/ExampleSubgraph.wasm
       entities:

--- a/examples/example-subgraph/subgraph.yaml
+++ b/examples/example-subgraph/subgraph.yaml
@@ -1,5 +1,5 @@
-specVersion: 0.0.2
-description: "example of a subgraph"
+specVersion: 0.0.5
+description: 'example of a subgraph'
 repository: https://github.com/graphprotocol/graph-cli.git
 schema:
   file: ./schema.graphql
@@ -12,7 +12,7 @@ dataSources:
       abi: ExampleContract
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.5
+      apiVersion: 0.0.7
       language: wasm/assemblyscript
       file: ./src/mapping.ts
       entities:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphprotocol/graph-cli",
-  "version": "0.35.0-best-practices",
+  "version": "0.35.0",
   "license": "(Apache-2.0 OR MIT)",
   "description": "CLI for building for and deploying to The Graph",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphprotocol/graph-cli",
-  "version": "0.35.0",
+  "version": "0.35.0-best-practices",
   "license": "(Apache-2.0 OR MIT)",
   "description": "CLI for building for and deploying to The Graph",
   "dependencies": {

--- a/src/protocols/ethereum/scaffold/manifest.js
+++ b/src/protocols/ethereum/scaffold/manifest.js
@@ -8,7 +8,7 @@ const source = ({ contract, contractName }) => `
 
 const mapping = ({ abi, contractName }) => `
       kind: ethereum/events
-      apiVersion: 0.0.5
+      apiVersion: 0.0.7
       language: wasm/assemblyscript
       entities:
         ${abiEvents(abi)

--- a/src/protocols/ethereum/scaffold/mapping.js
+++ b/src/protocols/ethereum/scaffold/mapping.js
@@ -14,12 +14,12 @@ const generatePlaceholderHandlers = ({ abi, events, contractName }) =>
     export function handle${event._alias}(event: ${event._alias}): void {
       // Entities can be loaded from the store using a string ID; this ID
       // needs to be unique across all entities of the same type
-      let entity = ExampleEntity.load(event.transaction.from.toHex())
+      let entity = ExampleEntity.load(event.transaction.from)
 
       // Entities only exist after they have been saved to the store;
       // \`null\` checks allow to create entities on demand
       if (!entity) {
-        entity = new ExampleEntity(event.transaction.from.toHex())
+        entity = new ExampleEntity(event.transaction.from)
 
         // Entity fields can be set using simple assignments
         entity.count = BigInt.fromI32(0)

--- a/src/scaffold/cosmos.test.js
+++ b/src/scaffold/cosmos.test.js
@@ -7,17 +7,15 @@ const protocol = new Protocol('cosmos')
 const scaffoldOptions = {
   protocol,
   network: 'cosmoshub-4',
-  contractName: 'CosmosHub'
+  contractName: 'CosmosHub',
 }
 
 const scaffold = new Scaffold(scaffoldOptions)
 
 describe('Cosmos subgraph scaffolding', () => {
   test('Manifest', () => {
-    expect(
-      scaffold.generateManifest(),
-    ).toEqual(`\
-specVersion: 0.0.1
+    expect(scaffold.generateManifest()).toEqual(`\
+specVersion: 0.0.5
 schema:
   file: ./schema.graphql
 dataSources:

--- a/src/scaffold/ethereum.test.js
+++ b/src/scaffold/ethereum.test.js
@@ -76,7 +76,7 @@ const scaffoldOptions = {
   abi: TEST_ABI,
   contract: '0xf87e31492faf9a91b02ee0deaad50d51d56d5d4d',
   network: 'kovan',
-  contractName: 'Contract'
+  contractName: 'Contract',
 }
 
 const scaffold = new Scaffold(scaffoldOptions)
@@ -88,10 +88,8 @@ const scaffoldWithIndexEvents = new Scaffold({
 
 describe('Ethereum subgraph scaffolding', () => {
   test('Manifest', () => {
-    expect(
-      scaffold.generateManifest(),
-    ).toEqual(`\
-specVersion: 0.0.1
+    expect(scaffold.generateManifest()).toEqual(`\
+specVersion: 0.0.5
 schema:
   file: ./schema.graphql
 dataSources:
@@ -103,7 +101,7 @@ dataSources:
       abi: Contract
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.5
+      apiVersion: 0.0.7
       language: wasm/assemblyscript
       entities:
         - ExampleEvent

--- a/src/scaffold/ethereum.test.js
+++ b/src/scaffold/ethereum.test.js
@@ -145,7 +145,6 @@ type ExampleEvent @entity(immutable: true) {
   c_c3_value1: String! # string
   c_c3_value2: Bytes! # bytes32
   d: String! # string
-
   # Block & transaction info
   blockNumber: BigInt!
   blockHash: Bytes!
@@ -159,7 +158,6 @@ type ExampleEvent1 @entity(immutable: true) {
 
   # Event params
   a: Bytes! # bytes32
-
   # Block & transaction info
   blockNumber: BigInt!
   blockHash: Bytes!
@@ -237,7 +235,7 @@ import { ExampleEvent, ExampleEvent1 } from "../generated/schema"
 
 export function handleExampleEvent(event: ExampleEventEvent): void {
   let entity = new ExampleEvent(
-    event.transaction.hash.concatI32(event.logIndex.toI32()),
+    event.transaction.hash.concatI32(event.logIndex.toI32())
   )
   entity.a = event.params.a
   entity.b = event.params.b
@@ -261,7 +259,7 @@ export function handleExampleEvent(event: ExampleEventEvent): void {
 
 export function handleExampleEvent1(event: ExampleEvent1Event): void {
   let entity = new ExampleEvent1(
-    event.transaction.hash.concatI32(event.logIndex.toI32()),
+    event.transaction.hash.concatI32(event.logIndex.toI32())
   )
   entity.a = event.params.a
 

--- a/src/scaffold/ethereum.test.js
+++ b/src/scaffold/ethereum.test.js
@@ -146,7 +146,6 @@ type ExampleEvent @entity(immutable: true) {
   blockNumber: BigInt!
   blockTimestamp: BigInt!
   transactionHash: Bytes!
-  logIndex: BigInt!
 }
 
 type ExampleEvent1 @entity(immutable: true) {
@@ -155,7 +154,6 @@ type ExampleEvent1 @entity(immutable: true) {
   blockNumber: BigInt!
   blockTimestamp: BigInt!
   transactionHash: Bytes!
-  logIndex: BigInt!
 }
 `)
   })
@@ -243,7 +241,6 @@ export function handleExampleEvent(event: ExampleEventEvent): void {
   entity.blockNumber = event.block.number
   entity.blockTimestamp = event.block.timestamp
   entity.transactionHash = event.transaction.hash
-  entity.logIndex = event.logIndex
 
   entity.save()
 }
@@ -257,7 +254,6 @@ export function handleExampleEvent1(event: ExampleEvent1Event): void {
   entity.blockNumber = event.block.number
   entity.blockTimestamp = event.block.timestamp
   entity.transactionHash = event.transaction.hash
-  entity.logIndex = event.logIndex
 
   entity.save()
 }

--- a/src/scaffold/ethereum.test.js
+++ b/src/scaffold/ethereum.test.js
@@ -133,8 +133,6 @@ type ExampleEntity @entity {
     expect(scaffoldWithIndexEvents.generateSchema()).toEqual(`\
 type ExampleEvent @entity(immutable: true) {
   id: Bytes!
-
-  # Event params
   a: BigInt! # uint256
   b: [Bytes]! # bytes[4]
   param2: String! # string
@@ -145,9 +143,7 @@ type ExampleEvent @entity(immutable: true) {
   c_c3_value1: String! # string
   c_c3_value2: Bytes! # bytes32
   d: String! # string
-  # Block & transaction info
   blockNumber: BigInt!
-  blockHash: Bytes!
   blockTimestamp: BigInt!
   transactionHash: Bytes!
   logIndex: BigInt!
@@ -155,12 +151,8 @@ type ExampleEvent @entity(immutable: true) {
 
 type ExampleEvent1 @entity(immutable: true) {
   id: Bytes!
-
-  # Event params
   a: Bytes! # bytes32
-  # Block & transaction info
   blockNumber: BigInt!
-  blockHash: Bytes!
   blockTimestamp: BigInt!
   transactionHash: Bytes!
   logIndex: BigInt!
@@ -249,7 +241,6 @@ export function handleExampleEvent(event: ExampleEventEvent): void {
   entity.d = event.params.d
 
   entity.blockNumber = event.block.number
-  entity.blockHash = event.block.hash
   entity.blockTimestamp = event.block.timestamp
   entity.transactionHash = event.transaction.hash
   entity.logIndex = event.logIndex
@@ -264,7 +255,6 @@ export function handleExampleEvent1(event: ExampleEvent1Event): void {
   entity.a = event.params.a
 
   entity.blockNumber = event.block.number
-  entity.blockHash = event.block.hash
   entity.blockTimestamp = event.block.timestamp
   entity.transactionHash = event.transaction.hash
   entity.logIndex = event.logIndex

--- a/src/scaffold/index.js
+++ b/src/scaffold/index.js
@@ -3,17 +3,13 @@ const pkginfo = require('pkginfo')(module)
 const { strings } = require('gluegun')
 
 const GRAPH_CLI_VERSION = process.env.GRAPH_CLI_TESTS
-  // JSON.stringify should remove this key, we will install the local
-  // graph-cli for the tests using `npm link` instead of fetching from npm.
-  ? undefined
-  // For scaffolding real subgraphs
-  : `${module.exports.version}`
+  ? // JSON.stringify should remove this key, we will install the local
+    // graph-cli for the tests using `npm link` instead of fetching from npm.
+    undefined
+  : // For scaffolding real subgraphs
+    `${module.exports.version}`
 
-const {
-  abiEvents,
-  generateEventType,
-  generateExampleEntityType,
-} = require('./schema')
+const { abiEvents, generateEventType, generateExampleEntityType } = require('./schema')
 const { generateEventIndexingHandlers } = require('./mapping')
 const { generateTestsFiles } = require('./tests')
 const { getSubgraphBasename } = require('../command-helpers/subgraph')
@@ -38,10 +34,7 @@ module.exports = class Scaffold {
         scripts: {
           codegen: 'graph codegen',
           build: 'graph build',
-          deploy:
-            `graph deploy ` +
-            `--node ${this.node} ` +
-            this.subgraphName,
+          deploy: `graph deploy ` + `--node ${this.node} ` + this.subgraphName,
           'create-local': `graph create --node http://localhost:8020/ ${this.subgraphName}`,
           'remove-local': `graph remove --node http://localhost:8020/ ${this.subgraphName}`,
           'deploy-local':
@@ -49,13 +42,15 @@ module.exports = class Scaffold {
             `--node http://localhost:8020/ ` +
             `--ipfs http://localhost:5001 ` +
             this.subgraphName,
-          'test': 'graph test',
+          test: 'graph test',
         },
         dependencies: {
           '@graphprotocol/graph-cli': GRAPH_CLI_VERSION,
           '@graphprotocol/graph-ts': `0.28.1`,
         },
-        devDependencies: this.protocol.hasEvents() ? { 'matchstick-as': `0.5.0`} : undefined,
+        devDependencies: this.protocol.hasEvents()
+          ? { 'matchstick-as': `0.5.0` }
+          : undefined,
       }),
       { parser: 'json' },
     )
@@ -64,8 +59,9 @@ module.exports = class Scaffold {
   generateManifest() {
     const protocolManifest = this.protocol.getManifestScaffold()
 
-    return prettier.format(`
-specVersion: 0.0.1
+    return prettier.format(
+      `
+specVersion: 0.0.5
 schema:
   file: ./schema.graphql
 dataSources:
@@ -81,16 +77,11 @@ dataSources:
 
   generateSchema() {
     const hasEvents = this.protocol.hasEvents()
-    const events = hasEvents
-      ? abiEvents(this.abi).toJS()
-      : []
+    const events = hasEvents ? abiEvents(this.abi).toJS() : []
 
     return prettier.format(
       hasEvents && this.indexEvents
-        ? events.map(
-            event => generateEventType(event, this.protocol.name)
-          )
-            .join('\n\n')
+        ? events.map(event => generateEventType(event, this.protocol.name)).join('\n\n')
         : generateExampleEntityType(this.protocol, events),
       {
         parser: 'graphql',
@@ -110,18 +101,13 @@ dataSources:
 
   generateMapping() {
     const hasEvents = this.protocol.hasEvents()
-    const events = hasEvents
-      ? abiEvents(this.abi).toJS()
-      : []
+    const events = hasEvents ? abiEvents(this.abi).toJS() : []
 
     const protocolMapping = this.protocol.getMappingScaffold()
 
     return prettier.format(
       hasEvents && this.indexEvents
-        ? generateEventIndexingHandlers(
-            events,
-            this.contractName,
-          )
+        ? generateEventIndexingHandlers(events, this.contractName)
         : protocolMapping.generatePlaceholderHandlers({
             ...this,
             events,
@@ -133,21 +119,19 @@ dataSources:
   generateABIs() {
     return this.protocol.hasABIs()
       ? {
-        [`${this.contractName}.json`]: prettier.format(JSON.stringify(this.abi.data), {
-          parser: 'json',
-        }),
-      }
+          [`${this.contractName}.json`]: prettier.format(JSON.stringify(this.abi.data), {
+            parser: 'json',
+          }),
+        }
       : undefined
   }
 
   generateTests() {
     const hasEvents = this.protocol.hasEvents()
-    const events = hasEvents
-      ? abiEvents(this.abi).toJS()
-      : []
+    const events = hasEvents ? abiEvents(this.abi).toJS() : []
 
     return events.length > 0
-      ?  generateTestsFiles(this.contractName, events, this.indexEvents)
+      ? generateTestsFiles(this.contractName, events, this.indexEvents)
       : undefined
   }
 

--- a/src/scaffold/mapping.js
+++ b/src/scaffold/mapping.js
@@ -36,7 +36,6 @@ const generateEventIndexingHandlers = (events, contractName) =>
     ${generateEventFieldAssignments(event).join('\n')}
 
     entity.blockNumber = event.block.number
-    entity.blockHash = event.block.hash
     entity.blockTimestamp = event.block.timestamp
     entity.transactionHash = event.transaction.hash
     entity.logIndex = event.logIndex

--- a/src/scaffold/mapping.js
+++ b/src/scaffold/mapping.js
@@ -38,7 +38,6 @@ const generateEventIndexingHandlers = (events, contractName) =>
     entity.blockNumber = event.block.number
     entity.blockTimestamp = event.block.timestamp
     entity.transactionHash = event.transaction.hash
-    entity.logIndex = event.logIndex
 
     entity.save()
   }

--- a/src/scaffold/mapping.js
+++ b/src/scaffold/mapping.js
@@ -32,8 +32,15 @@ const generateEventIndexingHandlers = (events, contractName) =>
   export function handle${event._alias}(event: ${event._alias}Event): void {
     let entity = new ${
       event._alias
-    }(event.transaction.hash.toHex() + '-' + event.logIndex.toString())
+    }(event.transaction.hash.concatI32(event.logIndex.toI32()))
     ${generateEventFieldAssignments(event).join('\n')}
+
+    entity.blockNumber = event.block.number
+    entity.blockHash = event.block.hash
+    entity.blockTimestamp = event.block.timestamp
+    entity.transactionHash = event.transaction.hash
+    entity.logIndex = event.logIndex
+
     entity.save()
   }
     `,

--- a/src/scaffold/near.test.js
+++ b/src/scaffold/near.test.js
@@ -8,17 +8,15 @@ const scaffoldOptions = {
   protocol,
   contract: 'abc.def.near',
   network: 'near-mainnet',
-  contractName: 'Contract'
+  contractName: 'Contract',
 }
 
 const scaffold = new Scaffold(scaffoldOptions)
 
 describe('NEAR subgraph scaffolding', () => {
   test('Manifest', () => {
-    expect(
-      scaffold.generateManifest(),
-    ).toEqual(`\
-specVersion: 0.0.1
+    expect(scaffold.generateManifest()).toEqual(`\
+specVersion: 0.0.5
 schema:
   file: ./schema.graphql
 dataSources:

--- a/src/scaffold/schema.js
+++ b/src/scaffold/schema.js
@@ -35,8 +35,6 @@ const generateEventType = (event, protocolName) => `type ${
   event._alias
 } @entity(immutable: true) {
       id: Bytes!
-
-      # Event params
       ${event.inputs
         .reduce(
           (acc, input, index) =>
@@ -44,9 +42,7 @@ const generateEventType = (event, protocolName) => `type ${
           [],
         )
         .join('\n')}  
-      # Block & transaction info
       blockNumber: BigInt!
-      blockHash: Bytes!
       blockTimestamp: BigInt!
       transactionHash: Bytes!
       logIndex: BigInt!

--- a/src/scaffold/schema.js
+++ b/src/scaffold/schema.js
@@ -45,7 +45,6 @@ const generateEventType = (event, protocolName) => `type ${
       blockNumber: BigInt!
       blockTimestamp: BigInt!
       transactionHash: Bytes!
-      logIndex: BigInt!
     }`
 
 const generateExampleEntityType = (protocol, events) => {


### PR DESCRIPTION
With these changes I want to make sure that newly initialised subgraphs follow best practices:
- Latest `specVersion` and `abiVersion`
- Using Bytes as IDs
- Immutable entities for events
- Auto-generated event entities enriched with `blockNumber`, ~`blockHash`~, `blockTimestamp`, `transactionHash` and ~`logIndex`~ to have a more powerful boilerplate
- Ask for index events during init-dialog
`✔ Index contract events as entities (Y/n) · true`