### PR TITLE
deps: update graph-ts to 0.29.1

### DIFF
--- a/.changeset/tall-months-fly.md
+++ b/.changeset/tall-months-fly.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': patch
+---
+
+update graph-ts to 0.29.1

--- a/examples/basic-event-handlers/package.json
+++ b/examples/basic-event-handlers/package.json
@@ -10,7 +10,7 @@
     "deploy-test": "../../packages/cli/bin/graph deploy test/basic-event-handlers --version-label v0.0.1 --ipfs http://localhost:15001 --node http://127.0.0.1:18020"
   },
   "devDependencies": {
-    "@graphprotocol/graph-ts": "0.28.1",
+    "@graphprotocol/graph-ts": "0.29.1",
     "apollo-fetch": "^0.7.0"
   },
   "dependencies": {

--- a/examples/example-subgraph/package.json
+++ b/examples/example-subgraph/package.json
@@ -8,7 +8,7 @@
     "build-wast": "../../packages/cli/bin/graph build -t wast subgraph.yaml"
   },
   "devDependencies": {
-    "@graphprotocol/graph-ts": "0.28.1"
+    "@graphprotocol/graph-ts": "0.29.1"
   },
   "resolutions": {
     "assemblyscript": "0.19.10"

--- a/packages/cli/src/scaffold/index.js
+++ b/packages/cli/src/scaffold/index.js
@@ -46,7 +46,7 @@ module.exports = class Scaffold {
         },
         dependencies: {
           '@graphprotocol/graph-cli': GRAPH_CLI_VERSION,
-          '@graphprotocol/graph-ts': `0.28.1`,
+          '@graphprotocol/graph-ts': `0.29.1`,
         },
         devDependencies: this.protocol.hasEvents()
           ? { 'matchstick-as': `0.5.0` }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
 
   examples/basic-event-handlers:
     specifiers:
-      '@graphprotocol/graph-ts': 0.28.1
+      '@graphprotocol/graph-ts': 0.29.1
       apollo-fetch: ^0.7.0
       babel-polyfill: 6.26.0
       babel-register: 6.26.0
@@ -28,14 +28,14 @@ importers:
       truffle: 5.0.12
       truffle-hdwallet-provider: 1.0.6
     devDependencies:
-      '@graphprotocol/graph-ts': 0.28.1
+      '@graphprotocol/graph-ts': 0.29.1
       apollo-fetch: 0.7.0
 
   examples/example-subgraph:
     specifiers:
-      '@graphprotocol/graph-ts': 0.28.1
+      '@graphprotocol/graph-ts': 0.29.1
     devDependencies:
-      '@graphprotocol/graph-ts': 0.28.1
+      '@graphprotocol/graph-ts': 0.29.1
 
   packages/cli:
     specifiers:
@@ -804,8 +804,8 @@ packages:
       js-yaml: 4.1.0
     dev: false
 
-  /@graphprotocol/graph-ts/0.28.1:
-    resolution: {integrity: sha512-1wMLQ0cu84/6Ml3zcz9ya1zFzrDAzCj0dIGZ7Rz9upnRSXg5jjqU4DefO/OYrl2K2/OPso9hSAr6I4aue2pL1Q==}
+  /@graphprotocol/graph-ts/0.29.1:
+    resolution: {integrity: sha512-GhAP2ijk3cTM0xBjoAFxEmdZbYl1BueCYqAGw5G7UyBX3EV8FWkvD5DMam6IkLGqXasBmelCFrROK3B5t6zVdg==}
     dependencies:
       assemblyscript: 0.19.10
     dev: true


### PR DESCRIPTION
This is to make `graph init` use the lastest version of `graph-ts`.

Also a bug was solved in it https://github.com/graphprotocol/graph-cli/issues/972