### PR TITLE
fix: target Node 14 and specify engine in package.json

### DIFF
--- a/.changeset/good-toys-mix.md
+++ b/.changeset/good-toys-mix.md
@@ -1,0 +1,5 @@
+---
+'@graphprotocol/graph-cli': patch
+---
+
+Target Node 14 and specify engine in package.json

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,6 +3,9 @@
   "version": "0.37.5",
   "description": "CLI for building for and deploying to The Graph",
   "license": "(Apache-2.0 OR MIT)",
+  "engines": {
+    "node": ">=14"
+  },
   "bin": {
     "graph": "dist/bin.js"
   },

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -3,7 +3,7 @@
     "outDir": "./dist",
     "moduleResolution": "node",
     "module": "commonjs",
-    "target": "es2022",
+    "target": "es2020",
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,


### PR DESCRIPTION
### TODO

- [x] Is this a breaking change? Do we want to support even lower Node versions? See https://github.com/graphprotocol/graph-cli/pull/1040#pullrequestreview-1254212875.